### PR TITLE
Remove shell prompt from code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For example:
 uvx prefect-cloud deploy hello_world --from https://github.com/jakekaplan/demo-flows/blob/main/hello_world.py
 ```
 ### From a Private Repo
-```shell
+```console
 # private repo
 uvx prefect-cloud deploy FUNCTION_NAME --from GITHUB_PY_FILE_URL --credentials GITHUB_TOKEN
 ```


### PR DESCRIPTION
When I copy/paste code blocks into my terminal, they fail with syntax errors because of the `$` at the beginning of each line.