### PR TITLE
fix credentials block name

### DIFF
--- a/src/prefect_cloud/cli/root.py
+++ b/src/prefect_cloud/cli/root.py
@@ -28,6 +28,7 @@ from prefect_cloud.schemas.objects import (
 )
 from prefect_cloud.utilities.flows import get_parameter_schema_from_content
 from prefect_cloud.utilities.tui import redacted
+from prefect_cloud.utilities.blocks import safe_block_name
 
 
 app = PrefectCloudTyper()
@@ -130,7 +131,9 @@ async def deploy(
             credentials_name = None
             if credentials:
                 progress.update(task, description="Syncing credentials...")
-                credentials_name = f"{github_ref.owner}-{github_ref.repo}-credentials"
+                credentials_name = safe_block_name(
+                    f"{github_ref.owner}-{github_ref.repo}-credentials"
+                )
                 await client.create_credentials_secret(credentials_name, credentials)
 
             pull_steps = [to_pull_step(github_ref, credentials_name)]

--- a/src/prefect_cloud/utilities/blocks.py
+++ b/src/prefect_cloud/utilities/blocks.py
@@ -1,0 +1,15 @@
+def safe_block_name(name: str) -> str:
+    """Sanitize a block name to conform to Prefect Cloud's naming requirements.
+
+    Block names must only contain lowercase letters, numbers, and dashes.
+
+    Args:
+        name: The name to sanitize
+
+    Returns:
+        A sanitized name containing only lowercase letters, numbers, and dashes
+    """
+    # Replace any non-alphanumeric chars with dashes and ensure lowercase
+    sanitized = "".join(c if c.isalnum() else "-" for c in name.lower())
+    # Remove consecutive dashes and strip dashes from ends
+    return "-".join(filter(None, sanitized.split("-")))

--- a/tests/test_utilities/test_blocks.py
+++ b/tests/test_utilities/test_blocks.py
@@ -1,0 +1,37 @@
+from prefect_cloud.utilities.blocks import safe_block_name
+
+
+def test_safe_block_name():
+    # Test basic lowercase conversion
+    assert safe_block_name("MyBlock") == "myblock"
+
+    # Test special characters replaced with dashes
+    assert safe_block_name("my@block!name") == "my-block-name"
+
+    # Test multiple consecutive special chars become single dash
+    assert safe_block_name("my!!block##name") == "my-block-name"
+
+    # Test handling of existing dashes
+    assert safe_block_name("my-block--name") == "my-block-name"
+
+    # Test stripping dashes from ends
+    assert safe_block_name("-my-block-") == "my-block"
+
+    # Test real world GitHub examples
+    assert (
+        safe_block_name("PrefectHQ/prefect-cloud-credentials")
+        == "prefecthq-prefect-cloud-credentials"
+    )
+    assert (
+        safe_block_name("User123/My-Repo!!-credentials")
+        == "user123-my-repo-credentials"
+    )
+
+    # Test empty segments are removed
+    assert safe_block_name("my---block") == "my-block"
+
+    # Test spaces handled correctly
+    assert safe_block_name("my block name") == "my-block-name"
+
+    # Test mixed case with special chars
+    assert safe_block_name("My!!BLOCK@@name") == "my-block-name"


### PR DESCRIPTION
Before we were generating the credentials name based off the repo, but we need to make sure it is sanitized to be a block name.