### PR TITLE
respect `GitHubFileRef` shorthand

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,5 @@ build-backend = "hatchling.build"
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
-colors = "yes"
 testpaths = ["tests"]
 env = ["CLOUD_ENV=prd"]

--- a/src/prefect_cloud/github.py
+++ b/src/prefect_cloud/github.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Literal
 from urllib.parse import urlparse
 
 from httpx import AsyncClient
@@ -8,6 +8,10 @@ from httpx import AsyncClient
 
 class FileNotFound(Exception):
     pass
+
+
+class InvalidGitHubURL(Exception):
+    """Exception raised when a GitHub URL is invalid."""
 
 
 @dataclass
@@ -24,35 +28,40 @@ class GitHubFileRef:
     def from_url(cls, url: str) -> "GitHubFileRef":
         """Parse a GitHub URL into its components.
 
-        Handles both blob and tree URLs:
+        Handles formats:
         - https://github.com/owner/repo/blob/branch/path/to/file.py
         - https://github.com/owner/repo/tree/branch/path/to/file.py
+        - gh/owner/repo@branch/path/to/file.py  (shorthand format)
 
         Args:
-            url: GitHub URL to parse
+            url: GitHub URL or shorthand to parse
 
         Returns:
             GitHubFileRef containing parsed components
 
         Raises:
-            ValueError: If URL is not a valid GitHub blob/tree URL
+            InvalidGitHubURL: If URL cannot be parsed into GitHub components
         """
+        try:
+            return cls._try_shorthand(url)
+        except ValueError:
+            pass
+
+        # Handle full URLs
         parsed = urlparse(url)
         if parsed.netloc != "github.com":
-            raise ValueError("Not a GitHub URL")
+            raise InvalidGitHubURL(f"Invalid GitHub URL: {url!r}")
 
         parts = parsed.path.strip("/").split("/")
         if len(parts) < 5:  # owner/repo/[blob|tree]/branch/filepath
-            raise ValueError(
-                "Invalid GitHub URL. Expected format: "
+            raise InvalidGitHubURL(
+                f"Invalid GitHub URL: {url!r}. Expected format: "
                 "https://github.com/owner/repo/blob|tree/branch/path/to/file.py"
             )
 
-        owner, repo = parts[:2]
-        ref_type = cast(Literal["blob", "tree"], parts[2])
-
+        owner, repo, ref_type = parts[:3]
         if ref_type not in ("blob", "tree"):
-            raise ValueError(
+            raise InvalidGitHubURL(
                 f"Invalid reference type '{ref_type}'. Must be 'blob' or 'tree'"
             )
 
@@ -61,6 +70,34 @@ class GitHubFileRef:
 
         return cls(
             owner=owner, repo=repo, branch=branch, filepath=filepath, ref_type=ref_type
+        )
+
+    @classmethod
+    def _try_shorthand(cls, url: str) -> "GitHubFileRef":
+        _SHORTHAND_PREFIX = "gh/"
+        if not url.startswith(_SHORTHAND_PREFIX):
+            raise ValueError("Not a shorthand URL")
+
+        parts = url[len(_SHORTHAND_PREFIX) :].split("/")
+        if len(parts) < 2:  # Need at least owner/repo
+            raise ValueError("Invalid shorthand format")
+
+        owner = parts[0]
+        repo = parts[1]
+        branch = "main"
+
+        if "@" in owner:
+            owner, branch = owner.split("@")
+        elif "@" in repo:
+            repo, branch = repo.split("@")
+
+        filepath = "/".join(parts[2:]) if len(parts) > 2 else ""
+        return cls(
+            owner=owner,
+            repo=repo,
+            branch=branch,
+            filepath=filepath,
+            ref_type="blob",
         )
 
     @property

--- a/tests/test_cli/test_root.py
+++ b/tests/test_cli/test_root.py
@@ -7,8 +7,8 @@ from typing import Iterable
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import readchar
-from rich.console import Console
 from click.testing import Result
+from rich.console import Console
 from typer.testing import CliRunner
 
 from prefect_cloud.cli.root import app
@@ -317,7 +317,7 @@ def test_deploy_private_repo_without_credentials():
                         "prefect",
                     ],
                     expected_code=1,
-                    expected_output_contains=("Unable to access file in Github."),
+                    expected_output_contains=("Unable to access file in GitHub"),
                 )
 
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,0 +1,55 @@
+from typing import Any
+
+import pytest
+
+from prefect_cloud.github import GitHubFileRef, InvalidGitHubURL
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        (
+            "https://github.com/prefecthq/prefect/blob/main/flows/hello.py",
+            {
+                "owner": "prefecthq",
+                "repo": "prefect",
+                "branch": "main",
+                "filepath": "flows/hello.py",
+            },
+        ),
+        (
+            "gh/prefecthq/prefect@dev/flows/hello.py",
+            {
+                "owner": "prefecthq",
+                "repo": "prefect",
+                "branch": "dev",
+                "filepath": "flows/hello.py",
+            },
+        ),
+        (
+            "gh/prefecthq/prefect/flows/hello.py",  # defaults to main branch
+            {
+                "owner": "prefecthq",
+                "repo": "prefect",
+                "branch": "main",
+                "filepath": "flows/hello.py",
+            },
+        ),
+    ],
+)
+def test_valid_github_url(url: str, expected: dict[str, Any]):
+    github_ref = GitHubFileRef.from_url(url)
+    for key, value in expected.items():
+        assert getattr(github_ref, key) == value
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com/org_slash_repo/hello.py",
+        "geethahb/prefecthq/prefect/flows/hello.py",
+    ],
+)
+def test_invalid_github_url(url: str):
+    with pytest.raises(InvalidGitHubURL, match="Invalid GitHub URL"):
+        GitHubFileRef.from_url(url)


### PR DESCRIPTION
stacked on #35 (all changes specific to this PR are in [87d7f0d](https://github.com/PrefectHQ/prefect-cloud/pull/37/commits/87d7f0d2fc4f05011dee1017026afe3ff8bd516d))

tries shorthand for `GitHubFileRef` or falls back to existing behavior
```bash
» alias prfx
prfx=prefect-cloud

» prfx deploy print_info -f gh/zzstoatzz/prefect-pack/flows/hello.py
Deployed print_info! 🎉
└─►
https://app.prefect.cloud/account/9b649228-0419-40e1-9e0d-44954b5c0ab6/workspace/e49488be-6d30-4980-94b2-a82a5edbb19c/deployments/deployment/74b5f9d4-aaa9-4792-b2ba-52688394970b
Run it with:
└─► prefect-cloud run print_info/print_info
```

and adds some tests