### PR TITLE
remove pinned prefect

### DIFF
--- a/src/prefect_cloud/cli/root.py
+++ b/src/prefect_cloud/cli/root.py
@@ -92,17 +92,10 @@ async def deploy(
         ) as progress:
             task = progress.add_task("Inspecting code...", total=None)
 
-            # Process env vars
-            try:
-                env_vars = process_key_value_pairs(env) if env else {}
-            except ValueError as e:
-                exit_with_error(str(e), progress=progress)
-
-            # Process parameters
-            try:
-                func_kwargs = process_key_value_pairs(parameters) if parameters else {}
-            except ValueError as e:
-                exit_with_error(str(e), progress=progress)
+            # Pre-process CLI arguments
+            pip_packages = get_dependencies(dependencies)
+            env_vars = process_key_value_pairs(env, progress=progress)
+            func_kwargs = process_key_value_pairs(parameters, progress=progress)
 
             # Get code contents
             github_ref = GitHubFileRef.from_url(file)
@@ -129,8 +122,6 @@ async def deploy(
             progress.update(task, description="Provisioning infrastructure...")
             work_pool = await client.ensure_managed_work_pool()
 
-            deployment_name = f"{function}"
-
             credentials_name = None
             if credentials:
                 progress.update(task, description="Syncing credentials...")
@@ -141,15 +132,9 @@ async def deploy(
 
             pull_steps = [to_pull_step(github_ref, credentials_name)]
 
-            # TODO temporary: remove this when the PR is merged
-            pip_packages = [
-                "git+https://github.com//PrefectHQ/prefect.git@add-missing-convert-statement"
-            ]
-            if dependencies:
-                pip_packages += get_dependencies(dependencies)
-
             progress.update(task, description="Deploying code...")
 
+            deployment_name = f"{function}"
             deployment_id = await client.create_managed_deployment(
                 deployment_name,
                 github_ref.filepath,

--- a/tests/test_cli/test_utilities.py
+++ b/tests/test_cli/test_utilities.py
@@ -1,0 +1,34 @@
+import pytest
+from prefect_cloud.cli.utilities import process_key_value_pairs
+import typer
+
+
+def test_process_key_value_pairs():
+    # Test basic key-value pairs
+    input_list = ["key1=value1", "key2=value2"]
+    expected = {"key1": "value1", "key2": "value2"}
+    assert process_key_value_pairs(input_list) == expected
+
+    # Test empty list
+    assert process_key_value_pairs([]) == {}
+    assert process_key_value_pairs(None) == {}
+
+    # Test single key-value pair
+    assert process_key_value_pairs(["key=value"]) == {"key": "value"}
+
+    # Test with spaces
+    input_list = ["key1=value1", "key2=value2"]
+    expected = {"key1": "value1", "key2": "value2"}
+    assert process_key_value_pairs(input_list) == expected
+
+    # Test with invalid format
+    with pytest.raises(typer.Exit):
+        process_key_value_pairs(["invalid_format"])
+
+    # Test with missing value
+    with pytest.raises(typer.Exit):
+        process_key_value_pairs(["key1=value1", "key2="])
+
+    # Test with missing key
+    with pytest.raises(typer.Exit):
+        process_key_value_pairs(["=value"])


### PR DESCRIPTION
CLOSES ENG-1352

Removes the pinned prefect version. Note: that things cannot automagically be flows at runtime until the next version after prefect 3.2.1.

This PR also consolidates some CLI preprocessing and adds tests for `process_key_value_pairs`