### PR TITLE
Update `deploy` syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ def hello_world():
 
 Deploy and run it using:
 ```
-prefect-cloud deploy <path/to/file.py:function_name> --from <source URL> --run
+prefect-cloud deploy <path/to/file.py:function_name> --from <source repo URL> --run
 ```
 e.g.
 ```bash

--- a/README.md
+++ b/README.md
@@ -40,35 +40,39 @@ def hello_world():
 ```
 
 Deploy and run it using:
+```
+prefect-cloud deploy <path/to/file.py:function_name> --from <source URL> --run
+```
+e.g.
 ```bash
-prefect-cloud deploy hello_world --from https://github.com/PrefectHQ/prefect-cloud/blob/main/examples/hello.py --run
+prefect-cloud deploy examples/hello.py:hello_world --from https://github.com/PrefectHQ/prefect-cloud/ --run
 ```
 
 ### Options
 **Only Deploy**
 ```bash
-prefect-cloud deploy ...
+prefect-cloud deploy ... --from ...
 ```
 
 **Deploy and Run**
 ```bash
-prefect-cloud deploy ... --run --parameters name=value
+prefect-cloud deploy ... --from ... --run --parameters name=value
 ```
 
 **Dependencies**
 
 ```bash
 # Package names
-prefect-cloud deploy ... --with pandas --with numpy
+prefect-cloud deploy ... --from ... --with pandas --with numpy
 
 # Or from files
-prefect-cloud deploy ... --with requirements.txt
-prefect-cloud deploy ... --with pyproject.toml
+prefect-cloud deploy ... --from ... --with requirements.txt
+prefect-cloud deploy ... --from ... --with pyproject.toml
 ```
 
 **Environment Variables**
 ```bash
-prefect-cloud deploy ... --env KEY=VALUE --env KEY2=VALUE2
+prefect-cloud deploy ... --from ... --env KEY=VALUE --env KEY2=VALUE2
 ```
 
 **Private Repositories**

--- a/src/prefect_cloud/cli/root.py
+++ b/src/prefect_cloud/cli/root.py
@@ -48,9 +48,9 @@ async def deploy(
         "-f",
         help=(
             "GitHub repository URL. Supports:\n\n"
-            "• Repo: https://github.com/owner/repo\n"
-            "• Specific branch: https://github.com/owner/repo/tree/branch\n"
-            "• Specific commit: https://github.com/owner/repo/tree/<commit-sha>\n"
+            "• Repo: github.com/owner/repo\n\n"
+            "• Specific branch: github.com/owner/repo/tree/branch\n\n"
+            "• Specific commit: github.com/owner/repo/tree/<commit-sha>\n\n"
         ),
         rich_help_panel="Source",
         show_default=False,

--- a/src/prefect_cloud/cli/root.py
+++ b/src/prefect_cloud/cli/root.py
@@ -16,9 +16,7 @@ from prefect_cloud.cli.utilities import (
 from prefect_cloud.dependencies import get_dependencies
 from prefect_cloud.github import (
     FileNotFound,
-    GitHubFileRef,
-    get_github_raw_content,
-    to_pull_step,
+    GitHubRepo,
 )
 from prefect_cloud.schemas.objects import (
     CronSchedule,
@@ -40,17 +38,19 @@ app = PrefectCloudTyper(
 @app.command(rich_help_panel="Deploy")
 async def deploy(
     function: str = typer.Argument(
-        help="The Python function to deploy as a flow",
+        help="The path to the Python function to deploy (format: path/to/file.py:function_name)",
         rich_help_panel="Arguments",
         show_default=False,
     ),
-    file: str = typer.Option(
+    repo: str = typer.Option(
         ...,
         "--from",
         "-f",
         help=(
-            "Source file containing the function to deploy. Supports:\n\n"
-            "• GitHub: e.g. github.com/owner/repo/blob/ref/path/to/file\n"
+            "GitHub repository URL. Supports:\n\n"
+            "• Repo: https://github.com/owner/repo\n"
+            "• Specific branch: https://github.com/owner/repo/tree/branch\n"
+            "• Specific commit: https://github.com/owner/repo/tree/<commit-sha>\n"
         ),
         rich_help_panel="Source",
         show_default=False,
@@ -108,15 +108,22 @@ async def deploy(
 
     Examples:
         Deploy a function:
-        $ prefect-cloud deploy my_function --from github.com/owner/repo/blob/main/flow.py
+        $ prefect-cloud deploy flows/hello.py:my_function --from github.com/owner/repo
+
+        Deploy from specific branch:
+        $ prefect-cloud deploy flows/hello.py:my_function --from github.com/owner/repo/tree/dev
 
         Deploy and run immediately:
-        $ prefect-cloud deploy my_function -f github.com/owner/repo/blob/main/flow.py --run
-
-        Deploy with dependencies:
-        $ prefect-cloud deploy my_function -f github.com/owner/repo/blob/main/flow.py --with prefect --with pandas
+        $ prefect-cloud deploy flows/hello.py:my_function -f github.com/owner/repo --run
     """
     ui_url, api_url, _ = await auth.get_cloud_urls_or_login()
+
+    # Split function_path into file path and function name
+    try:
+        filepath, function = function.split(":")
+        filepath = filepath.lstrip("/")
+    except ValueError:
+        exit_with_error("Invalid function. Expected path/to/file.py:function_name")
 
     async with await auth.get_prefect_cloud_client() as client:
         with Progress(
@@ -131,11 +138,10 @@ async def deploy(
             env_vars = process_key_value_pairs(env, progress=progress)
             func_kwargs = process_key_value_pairs(parameters, progress=progress)
 
-            # Get code contents
-            github_ref = GitHubFileRef.from_url(file)
-            raw_contents: str | None = None
+            # Get repository info and file contents
+            github_ref = GitHubRepo.from_url(repo)
             try:
-                raw_contents = await get_github_raw_content(github_ref, credentials)
+                raw_contents = await github_ref.get_file_contents(filepath, credentials)
             except FileNotFound:
                 exit_with_error(
                     "Unable to access file in Github. "
@@ -149,7 +155,7 @@ async def deploy(
                 )
             except ValueError:
                 exit_with_error(
-                    f"Could not find function '{function}' in {github_ref.filepath}",
+                    f"Could not find function '{function}' in {filepath}",
                     progress=progress,
                 )
 
@@ -164,18 +170,16 @@ async def deploy(
                 )
                 await client.create_credentials_secret(credentials_name, credentials)
 
-            pull_steps = [to_pull_step(github_ref, credentials_name)]
-
             progress.update(task, description="Deploying code...")
 
             deployment_name = f"{function}"
             deployment_id = await client.create_managed_deployment(
-                deployment_name,
-                github_ref.filepath,
-                function,
-                work_pool,
-                pull_steps,
-                parameter_schema,
+                deployment_name=deployment_name,
+                filepath=filepath,
+                function=function,
+                work_pool_name=work_pool,
+                pull_steps=[github_ref.to_pull_step(credentials_name)],
+                parameter_schema=parameter_schema,
                 job_variables={
                     "pip_packages": pip_packages,
                     "env": {"PREFECT_CLOUD_API_URL": api_url} | env_vars,

--- a/src/prefect_cloud/client.py
+++ b/src/prefect_cloud/client.py
@@ -748,18 +748,18 @@ class PrefectCloudClient(httpx.AsyncClient):
     async def create_managed_deployment(
         self,
         deployment_name: str,
-        filename: str,
-        flow_func: str,
+        filepath: str,
+        function: str,
         work_pool_name: str,
         pull_steps: list[dict[str, Any]],
         parameter_schema: ParameterSchema,
         job_variables: dict[str, Any] | None = None,
     ):
-        flow_id = await self.create_flow_from_name(flow_func)
+        flow_id = await self.create_flow_from_name(function)
 
         deployment_id = await self.create_deployment(
             flow_id=flow_id,
-            entrypoint=f"{filename}:{flow_func}",
+            entrypoint=f"{filepath}:{function}",
             name=deployment_name,
             work_pool_name=work_pool_name,
             pull_steps=pull_steps,

--- a/src/prefect_cloud/github.py
+++ b/src/prefect_cloud/github.py
@@ -27,9 +27,9 @@ class GitHubRepo:
 
     @classmethod
     def from_url(cls, url: str) -> "GitHubRepo":
-        """Parse a GitHub URL into its components.
+        """Parse a GitHub repo URL into its components.
 
-        Handles various GitHub URL formats:
+        Handles various URL formats:
         - https://github.com/owner/repo
         - github.com/owner/repo/tree/branch
         - github.com/owner/repo/tree/a1b2c3d
@@ -38,7 +38,7 @@ class GitHubRepo:
             url: GitHub URL to parse
 
         Returns:
-            GitHubRef containing parsed components
+            GitHubRepo
 
         Raises:
             ValueError: If URL format is invalid

--- a/src/prefect_cloud/github.py
+++ b/src/prefect_cloud/github.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
-from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any
 from urllib.parse import urlparse
 
 from httpx import AsyncClient
@@ -11,123 +10,98 @@ class FileNotFound(Exception):
 
 
 @dataclass
-class GitHubFileRef:
-    """Reference to a file in a GitHub repository."""
+class GitHubRepo:
+    """Reference to a GitHub repository."""
 
     owner: str
     repo: str
     ref: str  # Can be either a branch name or commit SHA
-    filepath: str
-    ref_type: Literal["blob", "tree"]
-
-    @classmethod
-    def from_url(cls, url: str) -> "GitHubFileRef":
-        """Parse a GitHub URL into its components.
-
-        Handles various GitHub URL formats:
-        - https://github.com/owner/repo/blob/branch/path/to/file.py
-        - github.com/owner/repo/blob/a1b2c3d/path/to/file.py (commit SHA)
-        - github.com/owner/repo/blob/path/to/file.py (uses first path component as ref)
-
-        Also handles tree URLs:
-        - https://github.com/owner/repo/tree/branch/path/to/dir
-        - github.com/owner/repo/tree/a1b2c3d/path/to/dir (commit SHA)
-        - github.com/owner/repo/tree/path/to/dir (uses first path component as ref)
-
-        Args:
-            url: GitHub URL to parse
-
-        Returns:
-            GitHubFileRef containing parsed components
-
-        Raises:
-            ValueError: If URL cannot be parsed into required components
-        """
-        # Handle URLs without protocol but with github.com
-        if url.startswith("github.com"):
-            url = "https://" + url
-
-        parsed = urlparse(url)
-        if parsed.netloc != "github.com":
-            raise ValueError("Not a GitHub URL. Must include 'github.com' in the URL")
-
-        # Remove leading/trailing slashes and split path
-        parts = parsed.path.strip("/").split("/")
-        if len(parts) < 4:  # Need at least owner/repo/[blob|tree]/ref
-            raise ValueError(
-                "Invalid GitHub URL. Expected format: "
-                "https://github.com/owner/repo/blob|tree/ref/path/to/file.py"
-            )
-
-        owner, repo = parts[:2]
-        ref_type = cast(Literal["blob", "tree"], parts[2])
-
-        if ref_type not in ("blob", "tree"):
-            raise ValueError(
-                f"Invalid reference type '{ref_type}'. Must be 'blob' or 'tree'"
-            )
-
-        # Always use the first component after blob/tree as the ref
-        ref = parts[3]
-        filepath = "/".join(parts[4:]) if len(parts) > 4 else ""
-
-        if not filepath:
-            raise ValueError(
-                "Invalid GitHub URL. Expected format: "
-                "https://github.com/owner/repo/blob|tree/ref/path/to/file.py"
-            )
-
-        return cls(
-            owner=owner, repo=repo, ref=ref, filepath=filepath, ref_type=ref_type
-        )
 
     @property
     def clone_url(self) -> str:
         """Get the HTTPS URL for cloning this repository."""
         return f"https://github.com/{self.owner}/{self.repo}.git"
 
-    @property
-    def directory(self) -> str:
-        """Get the directory containing this file."""
-        return str(Path(self.filepath).parent)
-
-    @property
-    def api_url(self) -> str:
-        """Get the GitHub API URL for this file."""
-        return f"https://api.github.com/repos/{self.owner}/{self.repo}/contents/{self.filepath}?ref={self.ref}"
-
     def __str__(self) -> str:
-        return f"github.com/{self.owner}/{self.repo} @ {self.ref} - {self.filepath}"
+        return f"github.com/{self.owner}/{self.repo} @ {self.ref}"
 
+    @classmethod
+    def from_url(cls, url: str) -> "GitHubRepo":
+        """Parse a GitHub URL into its components.
 
-def to_pull_step(
-    github_ref: GitHubFileRef, credentials_block: str | None = None
-) -> dict[str, Any]:
-    pull_step_kwargs = {
-        "repository": github_ref.clone_url,
-        "branch": github_ref.ref,
-    }
-    if credentials_block:
-        pull_step_kwargs["access_token"] = (
-            "{{ prefect.blocks.secret." + credentials_block + " }}"
-        )
+        Handles various GitHub URL formats:
+        - https://github.com/owner/repo
+        - github.com/owner/repo/tree/branch
+        - github.com/owner/repo/tree/a1b2c3d
 
-    return {"prefect.deployments.steps.git_clone": pull_step_kwargs}
+        Args:
+            url: GitHub URL to parse
 
+        Returns:
+            GitHubRef containing parsed components
 
-async def get_github_raw_content(
-    github_ref: GitHubFileRef, credentials: str | None = None
-) -> str:
-    """Get content of a file from GitHub API."""
-    headers: dict[str, str] = {
-        "Accept": "application/vnd.github.v3.raw",
-    }
-    if credentials:
-        headers["Authorization"] = f"Bearer {credentials}"
+        Raises:
+            ValueError: If URL format is invalid
+        """
+        normalized_url = url if "://" in url else f"https://{url}"
 
-    async with AsyncClient() as client:
-        response = await client.get(github_ref.api_url, headers=headers)
-        if response.status_code == 404:
-            raise FileNotFound(f"File not found: {github_ref}")
-        response.raise_for_status()
-        return response.text
+        parsed = urlparse(normalized_url)
+        if parsed.netloc != "github.com":
+            raise ValueError("Not a GitHub URL. Must include 'github.com' in the URL")
+
+        path_parts = [p for p in parsed.path.split("/") if p]
+        if len(path_parts) < 2:
+            raise ValueError("Invalid GitHub URL. Must include owner and repository")
+
+        owner, repo, *rest = path_parts
+        repo = repo.removesuffix(".git")
+        # Extract ref from /tree/branch format if present
+        ref = "main"
+        if len(rest) >= 2 and rest[0] == "tree":
+            ref = rest[1]
+
+        return cls(owner=owner, repo=repo, ref=ref)
+
+    async def get_file_contents(
+        self, filepath: str, credentials: str | None = None
+    ) -> str:
+        """Get the contents of a file from this repository.
+
+        Args:
+            filepath: Path to the file in the repository
+            credentials: Optional GitHub credentials for private repos
+
+        Returns:
+            The contents of the file as a string
+
+        Raises:
+            FileNotFound: If the file doesn't exist
+            ValueError: If the file can't be accessed
+        """
+        api_url = f"https://api.github.com/repos/{self.owner}/{self.repo}/contents/{filepath}?ref={self.ref}"
+        print(api_url)
+
+        headers: dict[str, str] = {
+            "Accept": "application/vnd.github.v3.raw",
+        }
+        if credentials:
+            headers["Authorization"] = f"Bearer {credentials}"
+
+        async with AsyncClient() as client:
+            response = await client.get(api_url, headers=headers)
+            if response.status_code == 404:
+                raise FileNotFound(f"File not found: {filepath} in {self}")
+            response.raise_for_status()
+            return response.text
+
+    def to_pull_step(self, credentials_block: str | None = None) -> dict[str, Any]:
+        pull_step_kwargs = {
+            "repository": self.clone_url,
+            "branch": self.ref,
+        }
+        if credentials_block:
+            pull_step_kwargs["access_token"] = (
+                "{{ prefect.blocks.secret." + credentials_block + " }}"
+            )
+
+        return {"prefect.deployments.steps.git_clone": pull_step_kwargs}

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,195 +1,136 @@
 import pytest
 from httpx import Response
 
-from prefect_cloud.github import FileNotFound, GitHubFileRef, get_github_raw_content
+from prefect_cloud.github import FileNotFound, GitHubRepo
 
 
-class TestGitHubFileRef:
-    def test_from_url_blob(self):
-        url = "https://github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/root.py"
-        ref = GitHubFileRef.from_url(url)
-
-        assert ref.owner == "PrefectHQ"
-        assert ref.repo == "prefect"
-        assert ref.ref == "main"
-        assert ref.filepath == "src/prefect/cli/root.py"
-        assert ref.ref_type == "blob"
-
-    def test_from_url_tree(self):
-        url = "https://github.com/PrefectHQ/prefect/tree/main/src/prefect/cli"
-        ref = GitHubFileRef.from_url(url)
+class TestGitHubRepo:
+    def test_from_url_basic(self):
+        """Test basic repo URL without branch."""
+        url = "https://github.com/PrefectHQ/prefect"
+        ref = GitHubRepo.from_url(url)
 
         assert ref.owner == "PrefectHQ"
         assert ref.repo == "prefect"
-        assert ref.ref == "main"
-        assert ref.filepath == "src/prefect/cli"
-        assert ref.ref_type == "tree"
+        assert ref.ref == "main"  # Default branch
 
-    def test_from_url_invalid_github(self):
-        with pytest.raises(ValueError, match="Not a GitHub URL"):
-            GitHubFileRef.from_url("https://gitlab.com/owner/repo/blob/main/file.py")
-
-    def test_from_url_invalid_format(self):
-        with pytest.raises(ValueError, match="Invalid GitHub URL"):
-            GitHubFileRef.from_url("https://github.com/owner/repo")
-
-    def test_from_url_invalid_ref_type(self):
-        with pytest.raises(ValueError, match="Invalid reference type"):
-            GitHubFileRef.from_url("https://github.com/owner/repo/invalid/main/file.py")
-
-    def test_clone_url(self):
-        ref = GitHubFileRef(
-            owner="PrefectHQ",
-            repo="prefect",
-            ref="main",
-            filepath="README.md",
-            ref_type="blob",
-        )
-        assert ref.clone_url == "https://github.com/PrefectHQ/prefect.git"
-
-    def test_directory(self):
-        ref = GitHubFileRef(
-            owner="PrefectHQ",
-            repo="prefect",
-            ref="main",
-            filepath="src/prefect/cli/root.py",
-            ref_type="blob",
-        )
-        assert ref.directory == "src/prefect/cli"
-
-    def test_api_url(self):
-        ref = GitHubFileRef(
-            owner="PrefectHQ",
-            repo="prefect",
-            ref="main",
-            filepath="README.md",
-            ref_type="blob",
-        )
-        assert (
-            ref.api_url
-            == "https://api.github.com/repos/PrefectHQ/prefect/contents/README.md?ref=main"
-        )
-
-    def test_str_representation(self):
-        ref = GitHubFileRef(
-            owner="PrefectHQ",
-            repo="prefect",
-            ref="main",
-            filepath="README.md",
-            ref_type="blob",
-        )
-        assert str(ref) == "github.com/PrefectHQ/prefect @ main - README.md"
-
-    def test_from_url_without_protocol(self):
-        url = "github.com/PrefectHQ/prefect/blob/main/README.md"
-        ref = GitHubFileRef.from_url(url)
+    def test_from_url_with_branch(self):
+        """Test repo URL with specific branch."""
+        url = "github.com/PrefectHQ/prefect/tree/dev"
+        ref = GitHubRepo.from_url(url)
 
         assert ref.owner == "PrefectHQ"
         assert ref.repo == "prefect"
-        assert ref.ref == "main"
-        assert ref.filepath == "README.md"
-        assert ref.ref_type == "blob"
+        assert ref.ref == "dev"
 
-    def test_from_url_with_http(self):
-        url = "http://github.com/PrefectHQ/prefect/blob/main/README.md"
-        ref = GitHubFileRef.from_url(url)
-
-        assert ref.owner == "PrefectHQ"
-        assert ref.repo == "prefect"
-        assert ref.ref == "main"
-        assert ref.filepath == "README.md"
-        assert ref.ref_type == "blob"
-
-    def test_from_url_requires_github_domain(self):
-        with pytest.raises(ValueError, match="Must include 'github.com' in the URL"):
-            GitHubFileRef.from_url("PrefectHQ/prefect/blob/main/README.md")
-
-    def test_from_url_with_multiple_path_segments(self):
-        url = "github.com/PrefectHQ/prefect/blob/main/src/prefect/cli/root.py"
-        ref = GitHubFileRef.from_url(url)
-
-        assert ref.owner == "PrefectHQ"
-        assert ref.repo == "prefect"
-        assert ref.ref == "main"
-        assert ref.filepath == "src/prefect/cli/root.py"
-        assert ref.ref_type == "blob"
-
-    def test_from_url_with_commit_sha(self):
-        url = "github.com/PrefectHQ/prefect/blob/a1b2c3d4e5f6/src/prefect/cli/root.py"
-        ref = GitHubFileRef.from_url(url)
+    def test_from_url_with_commit(self):
+        """Test repo URL with commit SHA."""
+        url = "github.com/PrefectHQ/prefect/tree/a1b2c3d4e5f6"
+        ref = GitHubRepo.from_url(url)
 
         assert ref.owner == "PrefectHQ"
         assert ref.repo == "prefect"
         assert ref.ref == "a1b2c3d4e5f6"
-        assert ref.filepath == "src/prefect/cli/root.py"
-        assert ref.ref_type == "blob"
 
-    def test_from_url_with_short_commit_sha(self):
-        url = "github.com/PrefectHQ/prefect/blob/a1b2c3d/README.md"
-        ref = GitHubFileRef.from_url(url)
+    def test_from_url_with_git_extension(self):
+        """Test repo URL with .git extension."""
+        url = "github.com/PrefectHQ/prefect.git"
+        ref = GitHubRepo.from_url(url)
 
         assert ref.owner == "PrefectHQ"
-        assert ref.repo == "prefect"
-        assert ref.ref == "a1b2c3d"
-        assert ref.filepath == "README.md"
-        assert ref.ref_type == "blob"
+        assert ref.repo == "prefect"  # .git is stripped
+        assert ref.ref == "main"
 
-    def test_from_url_without_ref(self):
-        url = "github.com/PrefectHQ/prefect/blob/README.md"
-        with pytest.raises(
-            ValueError,
-            match="Invalid GitHub URL. Expected format: https://github.com/owner/repo/blob|tree/ref/path/to/file.py",
-        ):
-            GitHubFileRef.from_url(url)
-
-    def test_from_url_with_tree_without_ref(self):
-        url = "github.com/PrefectHQ/prefect/tree/main/src/prefect"
-        ref = GitHubFileRef.from_url(url)
+    def test_from_url_without_protocol(self):
+        """Test URL without https://."""
+        url = "github.com/PrefectHQ/prefect"
+        ref = GitHubRepo.from_url(url)
 
         assert ref.owner == "PrefectHQ"
         assert ref.repo == "prefect"
         assert ref.ref == "main"
-        assert ref.filepath == "src/prefect"
-        assert ref.ref_type == "tree"
+
+    def test_from_url_with_http(self):
+        """Test URL with http:// instead of https://."""
+        url = "http://github.com/PrefectHQ/prefect"
+        ref = GitHubRepo.from_url(url)
+
+        assert ref.owner == "PrefectHQ"
+        assert ref.repo == "prefect"
+        assert ref.ref == "main"
+
+    def test_from_url_invalid_github(self):
+        """Test that non-GitHub URLs are rejected."""
+        with pytest.raises(ValueError, match="Not a GitHub URL"):
+            GitHubRepo.from_url("https://gitlab.com/owner/repo")
+
+    def test_from_url_invalid_format(self):
+        """Test that URLs without owner/repo are rejected."""
+        with pytest.raises(ValueError, match="Must include owner and repository"):
+            GitHubRepo.from_url("https://github.com/owner")
+
+    def test_clone_url(self):
+        """Test generation of clone URL."""
+        ref = GitHubRepo(
+            owner="PrefectHQ",
+            repo="prefect",
+            ref="main",
+        )
+        assert ref.clone_url == "https://github.com/PrefectHQ/prefect.git"
+
+    def test_str_representation(self):
+        """Test string representation of repo reference."""
+        ref = GitHubRepo(
+            owner="PrefectHQ",
+            repo="prefect",
+            ref="main",
+        )
+        assert str(ref) == "github.com/PrefectHQ/prefect @ main"
 
 
 class TestGitHubContent:
     @pytest.mark.asyncio
-    async def test_get_github_raw_content(self, respx_mock):
-        github_ref = GitHubFileRef(
+    async def test_get_file_contents(self, respx_mock):
+        """Test getting file contents from repo."""
+        github_ref = GitHubRepo(
             owner="PrefectHQ",
             repo="prefect",
             ref="main",
-            filepath="README.md",
-            ref_type="blob",
         )
 
         expected_content = "# Test Content"
-        respx_mock.get(github_ref.api_url).mock(
+        api_url = (
+            "https://api.github.com/repos/PrefectHQ/prefect/contents/README.md?ref=main"
+        )
+        respx_mock.get(api_url).mock(
             return_value=Response(status_code=200, text=expected_content)
         )
 
-        content = await get_github_raw_content(github_ref)
+        content = await github_ref.get_file_contents("README.md")
         assert content == expected_content
 
     @pytest.mark.asyncio
-    async def test_get_github_raw_content_with_credentials(self, respx_mock):
-        github_ref = GitHubFileRef(
+    async def test_get_file_contents_with_credentials(self, respx_mock):
+        """Test getting file contents with authentication."""
+        github_ref = GitHubRepo(
             owner="PrefectHQ",
             repo="prefect",
             ref="main",
-            filepath="README.md",
-            ref_type="blob",
         )
 
         test_token = "test-token"
         expected_content = "# Test Content"
+        api_url = (
+            "https://api.github.com/repos/PrefectHQ/prefect/contents/README.md?ref=main"
+        )
 
-        mock = respx_mock.get(github_ref.api_url).mock(
+        mock = respx_mock.get(api_url).mock(
             return_value=Response(status_code=200, text=expected_content)
         )
 
-        content = await get_github_raw_content(github_ref, credentials=test_token)
+        content = await github_ref.get_file_contents(
+            "README.md", credentials=test_token
+        )
         assert content == expected_content
 
         # Verify authorization header was sent
@@ -199,16 +140,49 @@ class TestGitHubContent:
         )
 
     @pytest.mark.asyncio
-    async def test_get_github_raw_content_file_not_found(self, respx_mock):
-        github_ref = GitHubFileRef(
+    async def test_get_file_contents_not_found(self, respx_mock):
+        """Test handling of non-existent files."""
+        github_ref = GitHubRepo(
             owner="PrefectHQ",
             repo="prefect",
             ref="main",
-            filepath="NONEXISTENT.md",
-            ref_type="blob",
         )
 
-        respx_mock.get(github_ref.api_url).mock(return_value=Response(status_code=404))
+        api_url = "https://api.github.com/repos/PrefectHQ/prefect/contents/NONEXISTENT.md?ref=main"
+        respx_mock.get(api_url).mock(return_value=Response(status_code=404))
 
-        with pytest.raises(FileNotFound):
-            await get_github_raw_content(github_ref)
+        with pytest.raises(FileNotFound, match="File not found: NONEXISTENT.md in"):
+            await github_ref.get_file_contents("NONEXISTENT.md")
+
+    def test_to_pull_step(self):
+        """Test generation of pull step configuration."""
+        github_ref = GitHubRepo(
+            owner="PrefectHQ",
+            repo="prefect",
+            ref="main",
+        )
+
+        pull_step = github_ref.to_pull_step()
+        assert pull_step == {
+            "prefect.deployments.steps.git_clone": {
+                "repository": "https://github.com/PrefectHQ/prefect.git",
+                "branch": "main",
+            }
+        }
+
+    def test_to_pull_step_with_credentials(self):
+        """Test generation of pull step with credentials."""
+        github_ref = GitHubRepo(
+            owner="PrefectHQ",
+            repo="prefect",
+            ref="main",
+        )
+
+        pull_step = github_ref.to_pull_step(credentials_block="test-creds")
+        assert pull_step == {
+            "prefect.deployments.steps.git_clone": {
+                "repository": "https://github.com/PrefectHQ/prefect.git",
+                "branch": "main",
+                "access_token": "{{ prefect.blocks.secret.test-creds }}",
+            }
+        }


### PR DESCRIPTION
Changes the primary deploy syntax to be from:
```
prefect-cloud deploy <func> --from <github url path to .py file>
```
to
```
prefect-cloud deploy <path/to/file.py:function_name> --from <source repo URL>
```

As part of this I did some light refactoring of the github handling