### PR TITLE
Support non-string `--parameter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ prefect-cloud deploy ... --from ...
 
 **Deploy and Run**
 ```bash
-prefect-cloud deploy ... --from ... --run --parameters name=value
+prefect-cloud deploy ... --from ... --run --parameter a=1 --parameter b=2 
 ```
 
 **Dependencies**

--- a/src/prefect_cloud/cli/root.py
+++ b/src/prefect_cloud/cli/root.py
@@ -88,9 +88,9 @@ async def deploy(
     ),
     parameters: list[str] = typer.Option(
         ...,
-        "--parameters",
+        "--parameter",
         "-p",
-        help="Flow Run parameters in NAME=VALUE format (only used with --run)",
+        help="Flow Run parameter in NAME=VALUE format (only used with --run)",
         default_factory=list,
         rich_help_panel="Execution",
         show_default=False,
@@ -136,7 +136,9 @@ async def deploy(
             # Pre-process CLI arguments
             pip_packages = get_dependencies(dependencies)
             env_vars = process_key_value_pairs(env, progress=progress)
-            func_kwargs = process_key_value_pairs(parameters, progress=progress)
+            func_kwargs = process_key_value_pairs(
+                parameters, progress=progress, as_json=True
+            )
 
             # Get repository info and file contents
             github_ref = GitHubRepo.from_url(repo)
@@ -252,9 +254,9 @@ async def schedule(
     ),
     parameters: list[str] = typer.Option(
         ...,
-        "--parameters",
+        "--parameter",
         "-p",
-        help="Flow Run parameters in NAME=VALUE format",
+        help="Function parameter in <NAME=VALUE> format (can be used multiple times)",
         default_factory=list,
     ),
 ):
@@ -271,8 +273,8 @@ async def schedule(
         Remove schedule:
         $ prefect-cloud schedule flow_name/deployment_name none
     """
-    parameters_dict = process_key_value_pairs(parameters) if parameters else {}
-    await deployments.schedule(deployment, schedule, parameters_dict)
+    func_kwargs = process_key_value_pairs(parameters, as_json=True)
+    await deployments.schedule(deployment, schedule, func_kwargs)
 
 
 @app.command(rich_help_panel="Manage Deployments")

--- a/tests/test_cli/test_utilities.py
+++ b/tests/test_cli/test_utilities.py
@@ -32,3 +32,44 @@ def test_process_key_value_pairs():
     # Test with missing key
     with pytest.raises(typer.Exit):
         process_key_value_pairs(["=value"])
+
+
+def test_process_key_value_pairs_json():
+    # Test with valid JSON values
+    input_list = [
+        "int=42",
+        "float=3.14",
+        "bool=true",
+        "null=null",
+        'string="hello"',
+        "array=[1,2,3]",
+        'object={"key":"value"}',
+    ]
+    expected = {
+        "int": 42,
+        "float": 3.14,
+        "bool": True,
+        "null": None,
+        "string": "hello",
+        "array": [1, 2, 3],
+        "object": {"key": "value"},
+    }
+    assert process_key_value_pairs(input_list, as_json=True) == expected
+
+    # Test mixing JSON and non-JSON values (non-JSON should remain as strings)
+    input_list = ["json_num=42", "regular=not_json", "json_array=[1,2,3]"]
+    expected = {"json_num": 42, "regular": "not_json", "json_array": [1, 2, 3]}
+    assert process_key_value_pairs(input_list, as_json=True) == expected
+
+    # Test invalid JSON should be treated as strings
+    input_list = ["invalid_array=[1,2,", "invalid_object={key:value}", "normal=string"]
+    expected = {
+        "invalid_array": "[1,2,",
+        "invalid_object": "{key:value}",
+        "normal": "string",
+    }
+    assert process_key_value_pairs(input_list, as_json=True) == expected
+
+    # Test empty values with as_json
+    assert process_key_value_pairs([], as_json=True) == {}
+    assert process_key_value_pairs(None, as_json=True) == {}


### PR DESCRIPTION
Previously because of how we were parsing these values only could be strings. Now we'll try to json serialize them and fall back to strings.

I've also renamed `--parameters` to `--parameter` as that seems to be more the convention as we're specifying it multiple times.