### PR TITLE
0.1.0 prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,67 +39,52 @@ def hello_world():
     print("Hello, World!")
 ```
 
-Deploy and run it using:
+### Deploy to Prefect Cloud
 ```
-prefect-cloud deploy <path/to/file.py:function_name> --from <source repo URL> --run
+prefect-cloud deploy <path/to/file.py:function_name> --from <source repo URL>
 ```
 e.g.
 ```bash
-prefect-cloud deploy examples/hello.py:hello_world --from https://github.com/PrefectHQ/prefect-cloud/ --run
+prefect-cloud deploy examples/hello.py:hello_world --from https://github.com/PrefectHQ/prefect-cloud/
 ```
 
-### Options
-**Only Deploy**
+### Run it with
 ```bash
-prefect-cloud deploy ... --from ...
-```
-
-**Deploy and Run**
+prefect-cloud run <flow_name>/<deployment_name>
+````
+e.g.
 ```bash
-prefect-cloud deploy ... --from ... --run --parameter a=1 --parameter b=2 
+prefect-cloud run hello_world/hello_world
 ```
 
-**Dependencies**
+### Schedule it with
+```bash
+prefect-cloud schedule <flow_name>/<deployment_name> <SCHEDULE>
+````
+e.g.
+```bash
+prefect-cloud schedule hello_world/hello_world "0 * * * *"
+```
 
+
+### Additional Options
+
+**Add Dependencies**
 ```bash
 # Add dependencies
-prefect-cloud deploy ... --from ... --with pandas --with numpy
+prefect-cloud deploy ... --with pandas --with numpy
 
 # Or install from requirements file at runtime
-prefect-cloud deploy ... --from ... --with-requirements </path/to/requirements.txt>
+prefect-cloud deploy ... --with-requirements </path/to/requirements.txt>
 ```
 
-**Environment Variables**
+**Inclcude Environment Variables**
 ```bash
-prefect-cloud deploy ... --from ... --env KEY=VALUE --env KEY2=VALUE2
+prefect-cloud deploy ... --env KEY=VALUE --env KEY2=VALUE2
 ```
 
-**Private Repositories**
+**From a Private Repository**
 ```bash
-prefect-cloud deploy ... --from https://github.com/myorg/private-repo/blob/main/flows.py --credentials GITHUB_TOKEN
+prefect-cloud deploy ... https://github.com/myorg/private-repo/blob/main/flows.py --credentials GITHUB_TOKEN
 ```
 
-## Managing Deployments
-
-List all deployments:
-```bash
-prefect-cloud ls
-```
-
-Run a deployment:
-```bash
-prefect-cloud run function_name/deployment_name
-```
-
-Schedule a deployment (using cron):
-```bash
-prefect-cloud schedule function_name/deployment_name "*/5 * * * *"  # Run every 5 minutes
-prefect-cloud schedule function_name/deployment_name none  # Remove schedule
-```
-Format: `minute hour day-of-month month day-of-week`
-
-Pause/Resume a deployment:
-```bash
-prefect-cloud pause function_name/deployment_name
-prefect-cloud resume function_name/deployment_name
-```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prefect-cloud"
-version = "0.1.0a4"
+version = "0.1.0"
 description = "Package for easily deploying to Prefect Cloud."
 readme = "README.md"
 authors = [{ name = "Prefect Technologies, Inc.", email = "help@prefect.io" }]

--- a/src/prefect_cloud/deployments.py
+++ b/src/prefect_cloud/deployments.py
@@ -54,11 +54,16 @@ async def delete(deployment_: str):
         await client.delete_deployment(deployment.id)
 
 
-async def run(deployment_: str) -> DeploymentFlowRun:
+async def run(
+    deployment_: str,
+    parameters: dict[str, Any] | None = None,
+) -> DeploymentFlowRun:
     deployment = await _get_deployment(deployment_)
 
     async with await get_prefect_cloud_client() as client:
-        return await client.create_flow_run_from_deployment_id(deployment.id)
+        return await client.create_flow_run_from_deployment_id(
+            deployment.id, parameters
+        )
 
 
 async def schedule(

--- a/uv.lock
+++ b/uv.lock
@@ -374,7 +374,7 @@ wheels = [
 
 [[package]]
 name = "prefect-cloud"
-version = "0.1.0a4"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
This PR makes some last minute adjustments for `0.1.0`

- Updates the README
- Removes the `--run` option from deploy, keeping our philosophy consistent that `deploy` is a singular action and then you should `run` or `schedule` your deployment after.
- Makes sure you can pass `--parameters` to `prefect-cloud run ...`
- Changes the output of the `deploy` and `run` commands to be a little nicer
<img width="1361" alt="Screenshot 2025-02-14 at 4 34 28 PM" src="https://github.com/user-attachments/assets/0e351295-deae-4190-ac68-ba1200befe54" />
- Bumps the version to `0.1.0`