### PR TITLE
Warns when the user's managed work pool is paused

### DIFF
--- a/src/prefect_cloud/deployments.py
+++ b/src/prefect_cloud/deployments.py
@@ -37,7 +37,7 @@ async def list() -> DeploymentListContext:
     )
 
 
-async def _get_deployment(deployment_: str) -> DeploymentResponse:
+async def get_deployment(deployment_: str) -> DeploymentResponse:
     async with await get_prefect_cloud_client() as client:
         try:
             deployment_id = UUID(deployment_)
@@ -48,7 +48,7 @@ async def _get_deployment(deployment_: str) -> DeploymentResponse:
 
 
 async def delete(deployment_: str):
-    deployment = await _get_deployment(deployment_)
+    deployment = await get_deployment(deployment_)
 
     async with await get_prefect_cloud_client() as client:
         await client.delete_deployment(deployment.id)
@@ -58,7 +58,7 @@ async def run(
     deployment_: str,
     parameters: dict[str, Any] | None = None,
 ) -> DeploymentFlowRun:
-    deployment = await _get_deployment(deployment_)
+    deployment = await get_deployment(deployment_)
 
     async with await get_prefect_cloud_client() as client:
         return await client.create_flow_run_from_deployment_id(
@@ -69,7 +69,7 @@ async def run(
 async def schedule(
     deployment_: str, schedule: str, parameters: Optional[dict[str, Any]] = None
 ):
-    deployment = await _get_deployment(deployment_)
+    deployment = await get_deployment(deployment_)
 
     async with await get_prefect_cloud_client() as client:
         for prior_schedule in deployment.schedules:

--- a/src/prefect_cloud/schemas/objects.py
+++ b/src/prefect_cloud/schemas/objects.py
@@ -130,6 +130,9 @@ class WorkPool(BaseModel):
     base_job_template: dict[str, Any] = Field(
         default_factory=dict, description="The work pool's base job template."
     )
+    is_paused: bool = Field(
+        default=False, description="Whether or not the work pool is paused."
+    )
 
 
 class CronSchedule(BaseModel):

--- a/src/prefect_cloud/schemas/responses.py
+++ b/src/prefect_cloud/schemas/responses.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from pydantic import Field, BaseModel
+from pydantic import BaseModel, Field
 
 import prefect_cloud.schemas.objects as objects
 
@@ -12,3 +12,4 @@ class DeploymentResponse(BaseModel):
     schedules: list[objects.DeploymentSchedule] = Field(
         default_factory=list, description="A list of schedules for the deployment."
     )
+    work_pool_name: str = Field(default=..., description="The name of the work pool.")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 import pytest
 import respx
 from httpx import Response
+
 from prefect_cloud.client import PrefectCloudClient
 from prefect_cloud.schemas.objects import (
     BlockDocument,
@@ -14,7 +15,7 @@ from prefect_cloud.schemas.objects import (
     WorkPool,
 )
 from prefect_cloud.schemas.responses import DeploymentResponse
-from prefect_cloud.utilities.exception import ObjectNotFound, ObjectAlreadyExists
+from prefect_cloud.utilities.exception import ObjectAlreadyExists, ObjectNotFound
 
 PREFECT_API_KEY = "test_key"
 PREFECT_API_URL = "https://api.prefect.cloud/api/accounts/123/workspaces/456"
@@ -31,6 +32,7 @@ def mock_deployment() -> DeploymentResponse:
         id=uuid4(),
         flow_id=uuid4(),
         name="test-deployment",
+        work_pool_name="test-pool",
         schedules=[],
     )
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -45,6 +45,7 @@ def mock_deployment() -> DeploymentResponse:
         id=uuid4(),
         flow_id=uuid4(),
         name="test-deployment",
+        work_pool_name="test-pool",
         schedules=[],
     )
 

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -50,6 +50,7 @@ def mock_deployment() -> DeploymentResponse:
         id=uuid4(),
         flow_id=uuid4(),
         name="test-deployment",
+        work_pool_name="test-pool",
         schedules=[],
     )
 


### PR DESCRIPTION
This has tripped me up a couple times while testing: my work pool will
be paused, but there's no indication of that when I `deploy` or `run`
flows.
