### PR TITLE
Makes `ls` work again after adding `work_pool_name`

### DIFF
--- a/src/prefect_cloud/client.py
+++ b/src/prefect_cloud/client.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any, Dict, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Union
 from uuid import UUID
 
 import httpx
@@ -26,6 +26,9 @@ from prefect_cloud.settings import settings
 from prefect_cloud.utilities.callables import ParameterSchema
 from prefect_cloud.utilities.exception import ObjectAlreadyExists, ObjectNotFound
 from prefect_cloud.utilities.generics import validate_list
+
+if TYPE_CHECKING:
+    from prefect_cloud.schemas.objects import Deployment
 
 PREFECT_MANAGED = "prefect:managed"
 HTTP_METHODS: TypeAlias = Literal["GET", "POST", "PUT", "DELETE", "PATCH"]
@@ -527,7 +530,7 @@ class PrefectCloudClient(httpx.AsyncClient):
         *,
         limit: int | None = None,
         offset: int = 0,
-    ) -> list["DeploymentResponse"]:
+    ) -> list["Deployment"]:
         """
         Query the Prefect API for deployments. Only deployments matching all
         the provided criteria will be returned.
@@ -540,7 +543,7 @@ class PrefectCloudClient(httpx.AsyncClient):
             a list of Deployment model representations
                 of the deployments
         """
-        from prefect_cloud.schemas.responses import DeploymentResponse
+        from prefect_cloud.schemas.objects import Deployment
 
         body: dict[str, Any] = {
             "limit": limit,
@@ -549,7 +552,7 @@ class PrefectCloudClient(httpx.AsyncClient):
         }
 
         response = await self.request("POST", "/deployments/filter", json=body)
-        return validate_list(DeploymentResponse, response.json())
+        return validate_list(Deployment, response.json())
 
     async def create_deployment_schedule(
         self,

--- a/src/prefect_cloud/deployments.py
+++ b/src/prefect_cloud/deployments.py
@@ -6,13 +6,18 @@ from uuid import UUID
 import tzlocal
 
 from prefect_cloud.auth import get_prefect_cloud_client
-from prefect_cloud.schemas.objects import CronSchedule, DeploymentFlowRun, Flow
+from prefect_cloud.schemas.objects import (
+    CronSchedule,
+    Deployment,
+    DeploymentFlowRun,
+    Flow,
+)
 from prefect_cloud.schemas.responses import DeploymentResponse
 
 
 @dataclass
 class DeploymentListContext:
-    deployments: list[DeploymentResponse]
+    deployments: list[Deployment]
     flows_by_id: dict[UUID, Flow]
     next_runs_by_deployment_id: dict[UUID, DeploymentFlowRun]
 

--- a/src/prefect_cloud/schemas/objects.py
+++ b/src/prefect_cloud/schemas/objects.py
@@ -120,6 +120,15 @@ class DeploymentSchedule(BaseModel):
     )
 
 
+class Deployment(BaseModel):
+    id: UUID = Field(default=..., description="The ID of the deployment.")
+    name: str = Field(default=..., description="The name of the deployment.")
+    flow_id: UUID = Field(default=..., description="The ID of the flow.")
+    schedules: list[DeploymentSchedule] = Field(
+        default_factory=list, description="A list of schedules for the deployment."
+    )
+
+
 class WorkPool(BaseModel):
     """An ORM representation of a work pool"""
 

--- a/src/prefect_cloud/schemas/responses.py
+++ b/src/prefect_cloud/schemas/responses.py
@@ -1,15 +1,7 @@
-from uuid import UUID
-
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 import prefect_cloud.schemas.objects as objects
 
 
-class DeploymentResponse(BaseModel):
-    id: UUID = Field(default=..., description="The ID of the deployment.")
-    name: str = Field(default=..., description="The name of the deployment.")
-    flow_id: UUID = Field(default=..., description="The ID of the flow.")
-    schedules: list[objects.DeploymentSchedule] = Field(
-        default_factory=list, description="A list of schedules for the deployment."
-    )
+class DeploymentResponse(objects.Deployment):
     work_pool_name: str = Field(default=..., description="The name of the work pool.")


### PR DESCRIPTION
In previous work, I added the `work_pool_name` to the `Deployment`, but
it isn't actually part of all `Deployment` responses (like the filter
responses).  This splits the core object from the `DeploymentResponse`
which has the additional info when we do a `GET` on the deployment.
