### PR TITLE
Infers and autocompletes the `--from` repo when possible

### DIFF
--- a/src/prefect_cloud/cli/completions.py
+++ b/src/prefect_cloud/cli/completions.py
@@ -3,6 +3,7 @@ import time
 from pathlib import Path
 
 from prefect_cloud.auth import get_cloud_urls_without_login, sync_cloud_client
+from prefect_cloud.github import get_local_repo_urls
 
 COMPLETION_CACHE = Path.home() / ".prefect" / "prefect-cloud-completions.json"
 CACHE_TTL = 86400
@@ -52,3 +53,7 @@ def complete_deployment(incomplete: str) -> list[str]:
             json.dump({"deployment_names": deployment_names}, f)
 
     return [name for name in deployment_names if name.startswith(incomplete)]
+
+
+def complete_repo(incomplete: str) -> list[str]:
+    return [url for url in get_local_repo_urls() if url.startswith(incomplete)]

--- a/src/prefect_cloud/cli/root.py
+++ b/src/prefect_cloud/cli/root.py
@@ -14,10 +14,7 @@ from prefect_cloud.cli.utilities import (
     process_key_value_pairs,
 )
 from prefect_cloud.dependencies import get_dependencies
-from prefect_cloud.github import (
-    FileNotFound,
-    GitHubRepo,
-)
+from prefect_cloud.github import FileNotFound, GitHubRepo, infer_repo_url
 from prefect_cloud.schemas.objects import (
     CronSchedule,
     DeploymentSchedule,
@@ -45,11 +42,14 @@ async def deploy(
         ...,
         "--from",
         "-f",
+        default_factory=infer_repo_url,
+        autocompletion=completions.complete_repo,
         help=(
             "GitHub repository URL. e.g.\n\n"
             "• Repo: github.com/owner/repo\n\n"
             "• Specific branch: github.com/owner/repo/tree/<branch>\n\n"
             "• Specific commit: github.com/owner/repo/tree/<commit-sha>\n\n"
+            "If not provided, the repository of the current directory will be used."
         ),
         rich_help_panel="Source",
         show_default=False,


### PR DESCRIPTION
Most folks will likely either be working outside of a git repo, or
within a git repo with an origin at Github.  In these cases, we can just
assume/default to the fact that they likely want _this_ repo to be their
code storage.  Here we add autocompletion and defaulting to guess the
repo when it's not provided.
