### PR TITLE
Rewords the summary from `prefect-cloud deploy` to educate more

### DIFF
--- a/src/prefect_cloud/cli/root.py
+++ b/src/prefect_cloud/cli/root.py
@@ -192,43 +192,41 @@ async def deploy(
             progress.update(task, completed=True, description="Code deployed!")
 
         deployment_url = f"{ui_url}/deployments/deployment/{deployment_id}"
-        run_prefix = "├─► Run: "
         run_cmd = f"prefect-cloud run {function}/{deployment_name}"
-        schedule_prefix = "├─► Schedule: "
-        schedule_cmd = f"prefect-cloud schedule {function}/{deployment_name} <SCHEDULE>"
-        blank_space_len = (
-            len(schedule_prefix + schedule_cmd) - len(run_prefix + run_cmd) + 1
-        )
-        deployed_msg = f"[bold]Deployed [cyan]{deployment_name}[/cyan]! 🎉[/bold]"
-        left_border = " ┌── "
-        right_border = " ─"
-
-        # Use schedule length directly since it's always longer
-        remaining_dashes = (
-            len(schedule_prefix + schedule_cmd)
-            - (len(left_border) + len(right_border))
-            - len(f"Deployed {deployment_name}! 🎉")
-            + 1
+        schedule_cmd = (
+            f"prefect-cloud schedule {function}/{deployment_name} '<CRON SCHEDULE>'"
         )
 
         app.console.print(
-            f"{left_border}{deployed_msg}{right_border}{'─' * remaining_dashes}┐\n",
-            f"{run_prefix}[bold][cyan]{run_cmd}[/cyan][/bold]{' ' * blank_space_len}│\n",
-            f"{schedule_prefix}[bold][cyan]{schedule_cmd}[/cyan][/bold] ┘ \n",
-            "└─► View:",
+            f"[bold]Deployed [cyan]{deployment_name}[/cyan] to Prefect Cloud! 🎉[/bold]\n",
+            "\n",
+            f"The repository [bold][cyan]{repo}[/cyan][/bold] will be cloned each time "
+            f"this deployment is run to execute the function "
+            f"[bold][cyan]{function}[/cyan][/bold] "
+            f"from the file [bold][cyan]{filepath}[/cyan][/bold].\n",
+            sep="",
+        )
+
+        app.console.print(
+            f"[bold]Run[/bold] it with: [bold][cyan]{run_cmd}[/cyan][/bold]\n",
+            f"[bold]Schedule[/bold] it with: [bold][cyan]{schedule_cmd}[/cyan][/bold]\n",
+            "[bold]View[/bold] it at: ",
             Text(deployment_url, style="link", justify="left"),
             soft_wrap=True,
+            sep="",
         )
 
         if work_pool.is_paused:
             work_pool_url = f"{ui_url}/work-pools"
             app.console.print(
-                "[bold][orange1]Note:[/orange1][/bold] Your managed work pool is",
-                "currently [bold]paused[/bold]. This will prevent the deployment "
-                "from running until it is [bold]resumed[/bold].  Visit",
+                "\n",
+                "[bold][orange1]Note:[/orange1][/bold] Your work pool is ",
+                "currently [bold]paused[/bold]. This will prevent the deployment ",
+                "from running until it is [bold]resumed[/bold].  Visit ",
                 Text(work_pool_url, style="link", justify="left"),
                 "to resume the work pool.",
                 soft_wrap=True,
+                sep="",
             )
 
 

--- a/tests/test_cli/test_root.py
+++ b/tests/test_cli/test_root.py
@@ -233,10 +233,10 @@ def test_deploy_command_basic():
                     ],
                     expected_code=0,
                     expected_output_contains=[
-                        "Deployed test_function! 🎉",
-                        "Run: prefect-cloud run test_function/test_function",
-                        "Schedule: prefect-cloud schedule test_function/test_function <SCHEDULE>",
-                        "View: https://ui.url/deployments/deployment/test-deployment-id",
+                        "Deployed test_function",
+                        "prefect-cloud run test_function/test_function",
+                        "prefect-cloud schedule test_function/test_function '<CRON SCHEDULE>'",
+                        "https://ui.url/deployments/deployment/test-deployment-id",
                     ],
                 )
 
@@ -316,10 +316,11 @@ def test_deploy_with_env_vars():
                     ],
                     expected_code=0,
                     expected_output_contains=[
-                        "Deployed test_function! 🎉",
-                        "Run: prefect-cloud run test_function/test_function",
-                        "Schedule: prefect-cloud schedule test_function/test_function <SCHEDULE>",
-                        "View: https://ui.url/deployments/deployment/test-deployment-id",
+                        "Deployed test_function",
+                        "prefect-cloud run test_function/test_function",
+                        "prefect-cloud schedule test_function/test_function '<CRON SCHEDULE>'",
+                        "https://ui.url/deployments/deployment/test-deployment-id",
+                        "github.com/owner/repo",
                     ],
                 )
 
@@ -370,10 +371,11 @@ def test_deploy_with_private_repo_credentials():
                     ],
                     expected_code=0,
                     expected_output_contains=[
-                        "Deployed test_function! 🎉",
-                        "Run: prefect-cloud run test_function/test_function",
-                        "Schedule: prefect-cloud schedule test_function/test_function <SCHEDULE>",
-                        "View: https://ui.url/deployments/deployment/test-deployment-id",
+                        "Deployed test_function",
+                        "prefect-cloud run test_function/test_function",
+                        "prefect-cloud schedule test_function/test_function '<CRON SCHEDULE>'",
+                        "https://ui.url/deployments/deployment/test-deployment-id",
+                        "github.com/owner/repo",
                     ],
                 )
 
@@ -528,10 +530,11 @@ def test_deploy_with_dependencies():
                     ],
                     expected_code=0,
                     expected_output_contains=[
-                        "Deployed test_function! 🎉",
-                        "Run: prefect-cloud run test_function/test_function",
-                        "Schedule: prefect-cloud schedule test_function/test_function <SCHEDULE>",
-                        "View: https://ui.url/deployments/deployment/test-deployment-id",
+                        "Deployed test_function",
+                        "prefect-cloud run test_function/test_function",
+                        "prefect-cloud schedule test_function/test_function '<CRON SCHEDULE>'",
+                        "https://ui.url/deployments/deployment/test-deployment-id",
+                        "github.com/owner/repo",
                     ],
                 )
 
@@ -589,10 +592,11 @@ def test_deploy_with_requirements_file():
                     ],
                     expected_code=0,
                     expected_output_contains=[
-                        "Deployed test_function! 🎉",
-                        "Run: prefect-cloud run test_function/test_function",
-                        "Schedule: prefect-cloud schedule test_function/test_function <SCHEDULE>",
-                        "View: https://ui.url/deployments/deployment/test-deployment-id",
+                        "Deployed test_function",
+                        "prefect-cloud run test_function/test_function",
+                        "prefect-cloud schedule test_function/test_function '<CRON SCHEDULE>'",
+                        "https://ui.url/deployments/deployment/test-deployment-id",
+                        "github.com/owner/repo",
                     ],
                 )
 


### PR DESCRIPTION
One thing we were concerned about with inferring the repo instead of
requiring `--from` is that it may not be as clear to a user that the
code must come from a remote repo.  We don't want to give them the
impression that it's their local code that's going to be deployed.

I realized that we were relying on `--from` to do a key point of
education; by making it required, we were educating the user that this
is required for MEX deployments.  `--from` was kinda noisy and
repetitive when you're already doing the standard thing of using a git
repo for your code, so I wanted to eliminate it.

Here I'm restructuring the output from `prefect-cloud deploy` to tell
the user explicitly what we're doing on their behalf (deploying a
function from a file from a repo to Prefect Cloud), and then making the
output a little simpler.

Feedback on the words and layout are most welcome!

Before:

```
$ CLOUD_ENV=dev prefect-cloud deploy hello.py:say_hello 
 ┌── Deployed say_hello! 🎉 ─────────────────────────────────────────┐
 ├─► Run: prefect-cloud run say_hello/say_hello                      │
 ├─► Schedule: prefect-cloud schedule say_hello/say_hello <SCHEDULE> ┘ 
 └─► View: https://app.prefect.dev/account/257bc8f1-6997-4088-bb5e-6ec1cfbe28a9/workspace/948362f2-21e1-4794-b0b0-651f5bc68ace/deployments/deployment/2f3e6f47-7dd0-44c1-9182-72c089678f03
Note: Your managed work pool is currently paused. This will prevent the deployment from running until it is resumed.  Visit https://app.prefect.dev/account/257bc8f1-6997-4088-bb5e-6ec1cfbe28a9/workspace/948362f2-21e1-4794-b0b0-651f5bc68ace/work-pools to resume the work pool.
```

![image](https://github.com/user-attachments/assets/e79de370-e377-4d86-8e21-a2e2d373be37)

After:

```
$ CLOUD_ENV=dev prefect-cloud deploy hello.py:say_hello 
Deployed say_hello to Prefect Cloud! 🎉

The repository https://github.com/chrisguidry/prefect-coolness will be cloned each time this deployment is run to execute the function say_hello from the 
file hello.py.

Run it with: prefect-cloud run say_hello/say_hello
Schedule it with: prefect-cloud schedule say_hello/say_hello '<CRON SCHEDULE>'
View it at: https://app.prefect.dev/account/257bc8f1-6997-4088-bb5e-6ec1cfbe28a9/workspace/948362f2-21e1-4794-b0b0-651f5bc68ace/deployments/deployment/2f3e6f47-7dd0-44c1-9182-72c089678f03

Note: Your work pool is currently paused. This will prevent the deployment from running until it is resumed.  Visit https://app.prefect.dev/account/257bc8f1-6997-4088-bb5e-6ec1cfbe28a9/workspace/948362f2-21e1-4794-b0b0-651f5bc68ace/work-poolsto resume the work pool.
```

![image](https://github.com/user-attachments/assets/60659330-14eb-4af7-ab1b-62be69cc8d7f)
