### PR TITLE
Generalize Callback Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ prefect-cloud deploy ... --env KEY=VALUE --env KEY2=VALUE2
 ```
 
 **From a Private Repository**
+
+*(Recommended!)*
+Install the Prefect Cloud Github App into the repository you want to deploy from. 
+This will allow you to deploy from private repositories without needing to provide a personal access token.
+```bash
+prefect-cloud github setup
+```
+
+Alternatively, you can provide a personal access token on each deploy:
 ```bash
 prefect-cloud deploy ... --from <private source repo URL> --credentials GITHUB_TOKEN
 ```

--- a/src/prefect_cloud/auth.py
+++ b/src/prefect_cloud/auth.py
@@ -203,6 +203,8 @@ async def key_is_valid(api_key: str) -> bool:
 
 @contextmanager
 def login_server() -> Generator[Any, None, None]:
+    """Runs a server to handle the login callback"""
+
     class LoginHandler(CallbackServerHandler):
         def process_get(self, query_params: dict[str, list[str]]) -> str | None:
             return query_params.get("key", [""])[0] or None
@@ -210,7 +212,6 @@ def login_server() -> Generator[Any, None, None]:
         def process_post(self, data: dict[str, Any]) -> str | None:
             return data.get("api_key") or None
 
-    """Runs a server to handle the login callback"""
     with callback_server(handler_class=LoginHandler) as callback_ctx:
         yield callback_ctx
 

--- a/src/prefect_cloud/auth.py
+++ b/src/prefect_cloud/auth.py
@@ -1,21 +1,19 @@
-import json
 import os
-import socket
 import threading
 import webbrowser
 from contextlib import asynccontextmanager, contextmanager
-from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
-from queue import Queue
 from typing import Any, AsyncGenerator, Generator, Sequence
-from urllib.parse import parse_qs, quote, urlparse
+from urllib.parse import quote
 from uuid import UUID
 
 import toml
 from pydantic import BaseModel, TypeAdapter
 
 from prefect_cloud.client import PrefectCloudClient, SyncPrefectCloudClient
+from prefect_cloud.utilities.callback import CallbackServerHandler, callback_server
 from prefect_cloud.utilities.tui import prompt_select_from_list
+from prefect_cloud.utilities.urls import extract_account_id, extract_workspace_id
 
 
 def _get_cloud_urls() -> tuple[str, str]:
@@ -112,6 +110,24 @@ def logout():
     remove_cloud_profile()
 
 
+async def get_account_id() -> UUID:
+    """Gets the account ID from the current cloud profile"""
+    _, api_url, _ = await get_cloud_urls_or_login()
+    account_id = extract_account_id(api_url)
+    if not account_id:
+        raise ValueError("No account ID found")
+    return account_id
+
+
+async def get_workspace_id() -> UUID:
+    """Gets the workspace ID from the current cloud profile"""
+    _, api_url, _ = await get_cloud_urls_or_login()
+    workspace_id = extract_workspace_id(api_url)
+    if not workspace_id:
+        raise ValueError("No workspace ID found")
+    return workspace_id
+
+
 @asynccontextmanager
 async def cloud_client(api_key: str) -> AsyncGenerator[PrefectCloudClient, None]:
     """Creates a client for the Prefect Cloud API"""
@@ -185,77 +201,33 @@ async def key_is_valid(api_key: str) -> bool:
         return response.status_code == 200
 
 
+@contextmanager
+def login_server() -> Generator[Any, None, None]:
+    class LoginHandler(CallbackServerHandler):
+        def process_get(self, query_params: dict[str, list[str]]) -> str | None:
+            return query_params.get("key", [""])[0] or None
+
+        def process_post(self, data: dict[str, Any]) -> str | None:
+            return data.get("api_key") or None
+
+    """Runs a server to handle the login callback"""
+    with callback_server(handler_class=LoginHandler) as callback_ctx:
+        yield callback_ctx
+
+
 def login_interactively() -> str | None:
     """Logs the user into Prefect Cloud interactively"""
-    result_queue: Queue[str | None] = Queue()
-    with login_server(result_queue) as uri:
-        login_url = f"{CLOUD_UI_URL}/auth/client?callback={quote(uri)}&g=true"
+
+    with login_server() as callback_ctx:
+        login_url = (
+            f"{CLOUD_UI_URL}/auth/client?callback={quote(callback_ctx.url)}&g=true"
+        )
 
         threading.Thread(
             target=webbrowser.open_new_tab, args=(login_url,), daemon=True
         ).start()
 
-        return result_queue.get()
-
-
-@contextmanager
-def login_server(result_queue: Queue[str | None]) -> Generator[str, None, None]:
-    """Runs a local server to handle the callback from Prefect Cloud"""
-
-    class LoginHandler(BaseHTTPRequestHandler):
-        def log_message(self, format: str, *args: Any) -> None:
-            pass
-
-        def add_cors_headers(self) -> None:
-            self.send_header("Access-Control-Allow-Origin", "*")
-            self.send_header("Access-Control-Allow-Headers", "*")
-            self.send_header("Access-Control-Allow-Methods", "POST, OPTIONS")
-
-        def do_OPTIONS(self) -> None:
-            self.send_response(200)
-            self.add_cors_headers()
-            self.end_headers()
-
-        def do_GET(self) -> None:
-            query_params = parse_qs(urlparse(self.path).query)
-            api_key = query_params.get("key", [""])[0] or None
-
-            self.send_response(200)
-            self.send_header("Content-type", "text/html")
-            self.end_headers()
-            self.wfile.write(b"""
-                <script>
-                if (window.opener) {
-                    window.opener.postMessage('auth-complete', '*')
-                }
-                </script>
-                <p>You can close this window.</p>
-            """)
-            result_queue.put(api_key or None)
-
-        def do_POST(self):
-            content_length = int(self.headers.get("Content-Length", 0))
-            body = self.rfile.read(content_length)
-            data = json.loads(body)
-            api_key = data.get("api_key")
-
-            self.send_response(200)
-            self.add_cors_headers()
-            self.end_headers()
-            self.wfile.write(b"{}")
-            result_queue.put(api_key or None)
-
-    with socket.socket() as sock:
-        sock.bind(("", 0))
-        port = sock.getsockname()[1]
-
-    server = HTTPServer(("localhost", port), LoginHandler)
-    threading.Thread(target=server.serve_forever, daemon=True).start()
-
-    try:
-        yield f"http://localhost:{port}"
-    finally:
-        server.server_close()
+        return callback_ctx.wait_for_callback()
 
 
 async def me(api_key: str) -> Me:

--- a/src/prefect_cloud/cli/__init__.py
+++ b/src/prefect_cloud/cli/__init__.py
@@ -1,0 +1,6 @@
+# pyright: reportUnusedImport=false
+
+# Import CLI submodules to register them to the app
+# isort: split
+
+from . import github  # noqa: F401

--- a/src/prefect_cloud/cli/github.py
+++ b/src/prefect_cloud/cli/github.py
@@ -1,0 +1,45 @@
+from prefect_cloud.auth import get_prefect_cloud_client
+from prefect_cloud.cli.root import app
+from prefect_cloud.cli.utilities import (
+    PrefectCloudTyper,
+    exit_with_error,
+    exit_with_success,
+)
+from prefect_cloud.github import install_github_app_interactively
+
+github_app = PrefectCloudTyper(help="Prefect Cloud + GitHub")
+app.add_typer(github_app, name="github", rich_help_panel="Code Source")
+
+
+@github_app.command()
+async def setup():
+    """
+    Setup Prefect Cloud GitHub integration
+    """
+    app.console.print("Setting up Prefect Cloud GitHub integration...")
+    async with await get_prefect_cloud_client() as client:
+        await install_github_app_interactively(client)
+        repos = await client.get_github_repositories()
+        repos_list = "\n".join([f"  - {repo}" for repo in repos])
+        exit_with_success(
+            f"Setup complete! You can now deploy from the following repositories:\n{repos_list}"
+        )
+
+
+@github_app.command()
+async def ls():
+    """
+    List GitHub repositories connected to Prefect Cloud.
+    """
+    async with await get_prefect_cloud_client() as client:
+        repos = await client.get_github_repositories()
+
+        if not repos:
+            exit_with_error(
+                "No repositories found! "
+                "Install the Prefect Cloud GitHub App with `prefect-cloud github setup`."
+            )
+
+        app.console.print("You can deploy from the following repositories:")
+        for repo in repos:
+            app.console.print(f"  - {repo}")

--- a/src/prefect_cloud/cli/utilities.py
+++ b/src/prefect_cloud/cli/utilities.py
@@ -25,6 +25,17 @@ def exit_with_error(
     raise typer.Exit(1)
 
 
+def exit_with_success(
+    message: str | Exception, progress: Progress | None = None
+) -> NoReturn:
+    from prefect_cloud.cli.root import app
+
+    if progress:
+        progress.stop()
+    app.console.print(message, style="green")
+    raise typer.Exit(0)
+
+
 def with_cli_exception_handling(fn: Callable[..., Any]) -> Callable[..., Any]:
     @functools.wraps(fn)
     def wrapper(*args: Any, **kwargs: Any) -> Any:

--- a/src/prefect_cloud/client.py
+++ b/src/prefect_cloud/client.py
@@ -43,6 +43,97 @@ class PrefectCloudClient(httpx.AsyncClient):
         httpx_settings.setdefault("base_url", api_url)
         super().__init__(**httpx_settings)
 
+    @property
+    def account_url(self) -> str:
+        """
+        Extract the account-level URL from the workspace URL.
+
+        For URLs like "https://api.prefect.cloud/api/accounts/123/workspaces/456",
+        returns "https://api.prefect.cloud/api/accounts/123"
+        """
+        base_url = str(self.base_url)
+        if "workspaces/" in base_url:
+            return base_url.split("workspaces/")[0].rstrip("/")
+        return base_url
+
+    async def account_request(
+        self, method: HTTP_METHODS, path: str, **kwargs: Any
+    ) -> httpx.Response:
+        """
+        Make a request to an account-level endpoint.
+
+        Args:
+            method: HTTP method to use
+            path: Path to append to the account URL
+            **kwargs: Additional arguments to pass to the request
+
+        Returns:
+            The HTTP response
+        """
+        url = f"{self.account_url}/{path.lstrip('/')}"
+        return await self.request(method, url, **kwargs)
+
+    async def get_github_state_token(self, redirect_url: str | None = None) -> str:
+        """
+        Get a state token for GitHub integration.
+
+        Returns:
+            The state token
+        """
+        response = await self.account_request(
+            "POST", "integrations/github/state-token", json=redirect_url
+        )
+        response.raise_for_status()
+        return response.json()["state_token"]
+
+    async def get_github_token(
+        self,
+        owner: str,
+        repository: str,
+    ) -> str | None:
+        """
+        Get a GitHub token for a specific repository.
+
+        Args:
+            owner: The GitHub repository owner
+            repository: The GitHub repository name
+
+        Returns:
+            The GitHub token or None
+        """
+        try:
+            response = await self.account_request(
+                "POST",
+                "integrations/github/token",
+                json={
+                    "owner": owner,
+                    "repository": repository,
+                },
+            )
+            response.raise_for_status()
+        except HTTPStatusError:
+            return None
+
+        return response.json()["token"]
+
+    async def get_github_repositories(self) -> list[str]:
+        """
+        Get a list of GitHub repositories that the account has access to.
+
+        Returns:
+            A list of repository names
+        """
+        response = await self.account_request(
+            "GET",
+            "integrations/github/repositories",
+        )
+        try:
+            response.raise_for_status()
+        except HTTPStatusError:
+            return []
+
+        return response.json()["repositories"]
+
     async def read_managed_work_pools(
         self,
     ) -> list["WorkPool"]:
@@ -239,7 +330,7 @@ class PrefectCloudClient(httpx.AsyncClient):
     async def get_most_recent_block_schema_for_block_type(
         self,
         block_type_id: "UUID",
-    ) -> "BlockSchema | None":
+    ) -> BlockSchema | None:
         """
         Fetches the most recent block schema for a specified block type ID.
 
@@ -264,7 +355,6 @@ class PrefectCloudClient(httpx.AsyncClient):
             response.raise_for_status()
         except HTTPStatusError:
             raise
-        from prefect_cloud.schemas.objects import BlockSchema
 
         return next(iter(validate_list(BlockSchema, response.json())), None)
 

--- a/src/prefect_cloud/utilities/callback.py
+++ b/src/prefect_cloud/utilities/callback.py
@@ -1,0 +1,146 @@
+from contextlib import contextmanager
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from queue import Queue
+from typing import Any, Generator, TypeVar, Type
+from urllib.parse import parse_qs, urlparse
+import json
+import socket
+import threading
+
+T = TypeVar("T")
+
+
+@dataclass
+class CallbackContext:
+    """Container for callback server context."""
+
+    url: str
+    queue: Queue[Any]
+
+    def wait_for_callback(self) -> Any:
+        """Wait for a callback result."""
+        return self.queue.get()
+
+
+class CallbackServerHandler(BaseHTTPRequestHandler):
+    """Base handler for callback server requests."""
+
+    result_queue: Queue[Any]
+
+    def log_message(self, format: str, *args: Any) -> None:
+        pass
+
+    def add_cors_headers(self) -> None:
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Headers", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+
+    def do_OPTIONS(self) -> None:
+        self.send_response(200)
+        self.add_cors_headers()
+        self.end_headers()
+
+    def do_GET(self) -> None:
+        query_params = parse_qs(urlparse(self.path).query)
+        result = self.process_get(query_params)
+
+        self.send_response(200)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+        self.wfile.write(b"""
+            <script>
+            if (window.opener) {
+                window.opener.postMessage('callback-complete', '*')
+            }
+            </script>
+            <p>You can close this window.</p>
+        """)
+        self.result_queue.put(result)
+
+    def do_POST(self) -> None:
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(content_length) if content_length > 0 else b"{}"
+        data: dict[str, Any] = json.loads(body) if body else {}
+        result = self.process_post(data)
+
+        self.send_response(200)
+        self.add_cors_headers()
+        self.end_headers()
+        self.wfile.write(b"{}")
+        self.result_queue.put(result)
+
+    def process_get(self, query_params: dict[str, list[str]]) -> Any:
+        """Process GET request and return a result to be put in the queue."""
+        return None
+
+    def process_post(self, data: dict[str, Any]) -> Any:
+        """
+        Process POST request and return a result to be put in the queue.
+        """
+        return None
+
+
+class CallbackServer:
+    """
+    Server that handles callbacks from external services.
+
+    To customize behavior, subclass CallbackServerHandler and pass it to the constructor.
+    """
+
+    def __init__(
+        self, handler_class: Type[CallbackServerHandler] = CallbackServerHandler
+    ):
+        """
+        Initialize the callback server.
+
+        Args:
+            handler_class: The request handler class to use. Defaults to CallbackServerHandler.
+        """
+        self.handler_class = handler_class
+        self.server = None
+        self.thread = None
+
+    @contextmanager
+    def run(self) -> Generator[CallbackContext, None, None]:
+        """
+        Run the server and yield a CallbackContext.
+
+        Yields:
+            CallbackContext
+        """
+        result_queue: Queue[Any] = Queue()
+
+        handler = type(
+            "ConfiguredHandler", (self.handler_class,), {"result_queue": result_queue}
+        )
+
+        with socket.socket() as sock:
+            sock.bind(("", 0))
+            port = sock.getsockname()[1]
+
+        self.server = HTTPServer(("localhost", port), handler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+        try:
+            yield CallbackContext(url=f"http://localhost:{port}", queue=result_queue)
+        finally:
+            if self.server:
+                self.server.shutdown()
+                self.server.server_close()
+
+
+@contextmanager
+def callback_server(
+    handler_class: Type[CallbackServerHandler] = CallbackServerHandler,
+) -> Generator[CallbackContext, None, None]:
+    """
+    Generic callback server context manager.
+
+    Yields:
+        CallbackContext: Container with the server URL and result queue.
+    """
+    server = CallbackServer(handler_class=handler_class)
+    with server.run() as context:
+        yield context

--- a/src/prefect_cloud/utilities/urls.py
+++ b/src/prefect_cloud/utilities/urls.py
@@ -1,0 +1,29 @@
+import re
+from uuid import UUID
+
+UUID_REGEX = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+
+ACCOUNTS_PREFIX = "accounts/"
+ACCOUNT_ID_REGEX = f"{ACCOUNTS_PREFIX}{UUID_REGEX}"
+
+WORKSPACES_PREFIX = "workspaces/"
+WORKSPACE_ID_REGEX = f"{WORKSPACES_PREFIX}{UUID_REGEX}"
+
+
+def convert_str_to_uuid(s: str) -> UUID | None:
+    try:
+        return UUID(s)
+    except ValueError:
+        return None
+
+
+def extract_account_id(s: str) -> UUID | None:
+    if res := re.search(ACCOUNT_ID_REGEX, s):
+        return convert_str_to_uuid(res.group().removeprefix(ACCOUNTS_PREFIX))
+    return None
+
+
+def extract_workspace_id(s: str) -> UUID | None:
+    if res := re.search(WORKSPACE_ID_REGEX, s):
+        return convert_str_to_uuid(res.group().removeprefix(WORKSPACES_PREFIX))
+    return None

--- a/tests/test_auth_interactive.py
+++ b/tests/test_auth_interactive.py
@@ -1,4 +1,3 @@
-from queue import Queue
 from unittest.mock import MagicMock, Mock
 
 import httpx
@@ -13,12 +12,12 @@ from prefect_cloud.auth import (
 
 def test_login_server_handles_cors_preflight():
     """login_server should handle CORS preflight requests."""
-    with login_server(Queue()) as callback_url:
-        response = httpx.options(callback_url)
+    with login_server() as callback_ctx:
+        response = httpx.options(callback_ctx.url)
         assert response.status_code == 200
         assert response.headers["Access-Control-Allow-Origin"] == "*"
         assert response.headers["Access-Control-Allow-Headers"] == "*"
-        assert response.headers["Access-Control-Allow-Methods"] == "POST, OPTIONS"
+        assert response.headers["Access-Control-Allow-Methods"] == "GET, POST, OPTIONS"
 
 
 @pytest.fixture

--- a/tests/test_cli/test_github_cli.py
+++ b/tests/test_cli/test_github_cli.py
@@ -1,0 +1,113 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from tests.test_cli.test_root import invoke_and_assert
+
+
+@pytest.fixture
+def mock_outgoing_calls(monkeypatch):
+    """Fixture to mock GitHub setup dependencies."""
+    install_mock = AsyncMock()
+    client_mock = AsyncMock()
+
+    context_manager = AsyncMock()
+    context_manager.__aenter__.return_value = client_mock
+    context_manager.__aexit__.return_value = None
+
+    async def mock_get_client():
+        return context_manager
+
+    monkeypatch.setattr(
+        "prefect_cloud.cli.github.install_github_app_interactively", AsyncMock()
+    )
+    monkeypatch.setattr(
+        "prefect_cloud.cli.github.get_prefect_cloud_client", mock_get_client
+    )
+
+    return install_mock, client_mock
+
+
+def test_github_setup(mock_outgoing_calls):
+    """Test the GitHub setup command."""
+    _, client_mock = mock_outgoing_calls
+
+    test_repos = ["owner/repo1", "owner/repo2"]
+    client_mock.get_github_repositories.return_value = test_repos
+
+    invoke_and_assert(
+        command=["github", "setup"],
+        expected_code=0,
+        expected_output_contains=[
+            "Setting up Prefect Cloud GitHub integration...",
+            "Setup complete!",
+            "You can now deploy from the following repositories:",
+            "- owner/repo1",
+            "- owner/repo2",
+        ],
+    )
+
+
+def test_github_setup_no_repositories(mock_outgoing_calls):
+    """Test the GitHub setup command when no repositories are available."""
+    _, client_mock = mock_outgoing_calls
+
+    client_mock.get_github_repositories.return_value = []
+
+    invoke_and_assert(
+        command=["github", "setup"],
+        expected_code=0,
+        expected_output_contains=[
+            "Setting up Prefect Cloud GitHub integration...",
+            "Setup complete!",
+            "You can now deploy from the following repositories:",
+        ],
+    )
+
+
+def test_github_ls_with_repositories(mock_outgoing_calls):
+    """Test the GitHub ls command when repositories are available."""
+    _, client_mock = mock_outgoing_calls
+
+    test_repos = ["owner/repo1", "owner/repo2", "owner/repo3"]
+    client_mock.get_github_repositories.return_value = test_repos
+
+    invoke_and_assert(
+        command=["github", "ls"],
+        expected_code=0,
+        expected_output_contains=[
+            "You can deploy from the following repositories:",
+            "- owner/repo1",
+            "- owner/repo2",
+            "- owner/repo3",
+        ],
+    )
+
+
+def test_github_ls_no_repositories(mock_outgoing_calls):
+    """Test the GitHub ls command when no repositories are available."""
+    _, client_mock = mock_outgoing_calls
+
+    client_mock.get_github_repositories.return_value = []
+
+    invoke_and_assert(
+        command=["github", "ls"],
+        expected_code=1,
+        expected_output_contains=[
+            "No repositories found!",
+            "Install the Prefect Cloud GitHub App with `prefect-cloud",
+            "github setup`.",
+        ],
+    )
+
+
+def test_github_ls_exception_handling(mock_outgoing_calls):
+    """Test the GitHub ls command when an exception occurs."""
+    _, client_mock = mock_outgoing_calls
+
+    client_mock.get_github_repositories.side_effect = Exception("Connection error")
+
+    invoke_and_assert(
+        command=["github", "ls"],
+        expected_code=1,
+        expected_output_contains="Connection error",
+    )

--- a/tests/test_utilities/test_callback.py
+++ b/tests/test_utilities/test_callback.py
@@ -1,0 +1,143 @@
+from queue import Queue
+
+import httpx
+from typing import Any, Dict
+
+from prefect_cloud.utilities.callback import (
+    CallbackServerHandler,
+    callback_server,
+)
+
+
+def test_callback_server_handles_cors_preflight():
+    """Callback server should handle CORS preflight requests."""
+    with callback_server() as callback_ctx:
+        response = httpx.options(callback_ctx.url)
+        assert response.status_code == 200
+        assert response.headers["Access-Control-Allow-Origin"] == "*"
+        assert response.headers["Access-Control-Allow-Headers"] == "*"
+        assert response.headers["Access-Control-Allow-Methods"] == "GET, POST, OPTIONS"
+
+
+def test_callback_server_basic_functionality():
+    """Callback server should start and provide a valid URL."""
+    with callback_server() as callback_ctx:
+        assert callback_ctx.url.startswith("http://localhost:")
+        assert isinstance(callback_ctx.queue, Queue)
+        assert callable(callback_ctx.wait_for_callback)
+
+
+def test_callback_server_custom_handler():
+    """Callback server should support custom handlers."""
+
+    class TestHandler(CallbackServerHandler):
+        def process_get(self, query_params: Dict[str, list[str]]) -> str:
+            return "test_get_handler"
+
+        def process_post(self, data: Dict[str, Any]) -> str:
+            return "test_post_handler"
+
+    with callback_server(handler_class=TestHandler) as callback_ctx:
+        response = httpx.get(callback_ctx.url)
+        assert response.status_code == 200
+
+        result = callback_ctx.wait_for_callback()
+        assert result == "test_get_handler"
+
+        response = httpx.post(callback_ctx.url, json={})
+        assert response.status_code == 200
+
+        result = callback_ctx.wait_for_callback()
+        assert result == "test_post_handler"
+
+
+def test_callback_server_get_parameters():
+    """Callback server should extract parameters from GET request."""
+
+    class TestGetHandler(CallbackServerHandler):
+        def process_get(self, query_params: Dict[str, list[str]]) -> Dict[str, str]:
+            return {
+                "param1": query_params.get("param1", [""])[0],
+                "param2": query_params.get("param2", [""])[0],
+            }
+
+    with callback_server(handler_class=TestGetHandler) as callback_ctx:
+        response = httpx.get(
+            callback_ctx.url, params={"param1": "value1", "param2": "value2"}
+        )
+        assert response.status_code == 200
+
+        result = callback_ctx.wait_for_callback()
+        assert result == {"param1": "value1", "param2": "value2"}
+
+
+def test_callback_server_post_json():
+    """Callback server should parse JSON data from POST request."""
+
+    class TestPostHandler(CallbackServerHandler):
+        def process_post(self, data: Dict[str, Any]) -> Dict[str, Any]:
+            return data
+
+    with callback_server(handler_class=TestPostHandler) as callback_ctx:
+        test_data = {"key1": "value1", "key2": 42, "nested": {"foo": "bar"}}
+        response = httpx.post(callback_ctx.url, json=test_data)
+        assert response.status_code == 200
+
+        result = callback_ctx.wait_for_callback()
+        assert result == test_data
+
+
+def test_callback_server_wait_for_callback():
+    """wait_for_callback() should return the first result from the queue."""
+
+    class TestDelayedHandler(CallbackServerHandler):
+        def process_get(self, query_params: Dict[str, list[str]]) -> str:
+            return "result"
+
+    with callback_server(handler_class=TestDelayedHandler) as callback_ctx:
+        httpx.get(callback_ctx.url)
+
+        result = callback_ctx.wait_for_callback()
+        assert result == "result"
+
+
+def test_callback_server_multiple_requests():
+    """Callback server should handle multiple requests in sequence."""
+    counter = 0
+
+    class CountingHandler(CallbackServerHandler):
+        def process_get(self, query_params: Dict[str, list[str]]) -> int:
+            nonlocal counter
+            counter += 1
+            return counter
+
+    with callback_server(handler_class=CountingHandler) as callback_ctx:
+        # Send multiple GET requests
+        for _ in range(3):
+            httpx.get(callback_ctx.url)
+
+        # Each request should increment the counter
+        assert callback_ctx.wait_for_callback() == 1
+        assert callback_ctx.wait_for_callback() == 2
+        assert callback_ctx.wait_for_callback() == 3
+
+
+def test_callback_server_html_response():
+    """Callback server should return HTML with the expected script for closing the window."""
+    with callback_server() as callback_ctx:
+        response = httpx.get(callback_ctx.url)
+        assert response.status_code == 200
+        assert response.headers["Content-type"] == "text/html"
+
+        assert "window.opener.postMessage('callback-complete', '*')" in response.text
+        assert "You can close this window." in response.text
+
+
+def test_callback_server_empty_post():
+    """Callback server should handle empty POST requests."""
+    with callback_server() as callback_ctx:
+        response = httpx.post(callback_ctx.url)
+        assert response.status_code == 200
+
+        # Default handler returns None
+        assert callback_ctx.wait_for_callback() is None

--- a/tests/test_utilities/test_urls.py
+++ b/tests/test_utilities/test_urls.py
@@ -1,0 +1,81 @@
+import uuid
+from prefect_cloud.utilities.urls import extract_account_id, extract_workspace_id
+
+
+def test_extract_account_id():
+    """Test extracting account IDs from strings."""
+    # Valid account IDs
+    test_uuid = uuid.uuid4()
+    test_strings = [
+        f"accounts/{test_uuid}",
+        f"https://example.com/accounts/{test_uuid}/details",
+        f"User belongs to accounts/{test_uuid} and other groups",
+        f"accounts/{test_uuid}/users/12345",
+    ]
+
+    for test_str in test_strings:
+        result = extract_account_id(test_str)
+        assert result == test_uuid
+
+    # Multiple account IDs
+    uuid1 = uuid.uuid4()
+    uuid2 = uuid.uuid4()
+    test_str = f"Found multiple accounts: accounts/{uuid1} and accounts/{uuid2}"
+    result = extract_account_id(test_str)
+    assert result == uuid1
+
+    # No account ID
+    test_strings = [
+        "No account ID here",
+        "account/123e4567-e89b-12d3-a456-426614174000",  # missing 's' in accounts
+        "accounts/invalid-uuid",
+        "",  # empty string
+    ]
+
+    for test_str in test_strings:
+        assert extract_account_id(test_str) is None
+
+
+def test_extract_workspace_id():
+    """Test extracting workspace IDs from strings."""
+    # Valid workspace IDs
+    test_uuid = uuid.uuid4()
+    test_strings = [
+        f"workspaces/{test_uuid}",
+        f"https://example.com/workspaces/{test_uuid}/projects",
+        f"User belongs to workspaces/{test_uuid} and other workspaces",
+        f"workspaces/{test_uuid}/tasks/54321",
+    ]
+
+    for test_str in test_strings:
+        result = extract_workspace_id(test_str)
+        assert result == test_uuid
+
+    # Multiple workspace IDs
+    uuid1 = uuid.uuid4()
+    uuid2 = uuid.uuid4()
+    test_str = f"Found multiple workspaces: workspaces/{uuid1} and workspaces/{uuid2}"
+    result = extract_workspace_id(test_str)
+    assert result == uuid1
+
+    # No workspace ID
+    test_strings = [
+        "No workspace ID here",
+        "workspace/123e4567-e89b-12d3-a456-426614174000",  # missing 's' in workspaces
+        "workspaces/invalid-uuid",
+        "",  # empty string
+    ]
+
+    for test_str in test_strings:
+        assert extract_workspace_id(test_str) is None
+
+    # Mixed account and workspace
+    account_uuid = uuid.uuid4()
+    workspace_uuid = uuid.uuid4()
+    test_str = f"accounts/{account_uuid}/workspaces/{workspace_uuid}"
+
+    result = extract_workspace_id(test_str)
+    assert result == workspace_uuid
+
+    result = extract_account_id(test_str)
+    assert result == account_uuid


### PR DESCRIPTION
This PR refactors the callback server being used for login into a general utility we can use to handle different type of callbacks. To customize behavior, users can implement a custom `CallbackServerHandler` to determine how they want to deal with the `POST/GET` requests.

This PR also adds utilities for extracting the current `account_id` and `workspace_id` (it's small enough I don't want to make a separate PR for it)  

related to ENG-1309