### PR TITLE
Prefect Cloud Github App

### DIFF
--- a/src/prefect_cloud/cli/__init__.py
+++ b/src/prefect_cloud/cli/__init__.py
@@ -1,0 +1,8 @@
+# pyright: reportUnusedImport=false
+
+import prefect_cloud.cli.root
+
+# Import CLI submodules to register them to the app
+# isort: split
+
+import prefect_cloud.cli.github  # noqa: F401

--- a/src/prefect_cloud/cli/github.py
+++ b/src/prefect_cloud/cli/github.py
@@ -19,13 +19,17 @@ async def setup():
     app.console.print("Setting up Prefect Cloud GitHub integration...")
     async with await get_prefect_cloud_client() as client:
         await install_github_app_interactively(client)
-    exit_with_success("Setup complete!")
+        repos = await client.get_github_repositories()
+        repos_list = "\n".join([f"  - {repo}" for repo in repos])
+        exit_with_success(
+            f"Setup complete! You can now deploy from the following repositories:\n{repos_list}"
+        )
 
 
 @github_app.command()
 async def ls():
     """
-    Initialize a new GitHub integration.
+    List GitHub repositories connected to Prefect Cloud.
     """
     async with await get_prefect_cloud_client() as client:
         repos = await client.get_github_repositories()
@@ -36,5 +40,6 @@ async def ls():
                 "Configure the Prefect Cloud GitHub integration with `prefect-cloud github setup`."
             )
 
+        app.console.print("You can deploy from the following repositories:")
         for repo in repos:
-            app.console.print(repo)
+            app.console.print(f"  - {repo}")

--- a/src/prefect_cloud/cli/github.py
+++ b/src/prefect_cloud/cli/github.py
@@ -1,0 +1,40 @@
+from prefect_cloud.auth import get_prefect_cloud_client
+from prefect_cloud.cli.root import app
+from prefect_cloud.cli.utilities import (
+    PrefectCloudTyper,
+    exit_with_error,
+    exit_with_success,
+)
+from prefect_cloud.github import install_github_app_interactively
+
+github_app = PrefectCloudTyper(help="Prefect Cloud + GitHub")
+app.add_typer(github_app, name="github", rich_help_panel="Code Source")
+
+
+@github_app.command()
+async def setup():
+    """
+    Initialize a new GitHub integration.
+    """
+    app.console.print("Setting up Prefect Cloud GitHub integration...")
+    async with await get_prefect_cloud_client() as client:
+        await install_github_app_interactively(client)
+    exit_with_success("Setup complete!")
+
+
+@github_app.command()
+async def ls():
+    """
+    Initialize a new GitHub integration.
+    """
+    async with await get_prefect_cloud_client() as client:
+        repos = await client.get_github_repositories()
+
+        if not repos:
+            exit_with_error(
+                "No repositories found! "
+                "Configure the Prefect Cloud GitHub integration with `prefect-cloud github setup`."
+            )
+
+        for repo in repos:
+            app.console.print(repo)

--- a/src/prefect_cloud/cli/github.py
+++ b/src/prefect_cloud/cli/github.py
@@ -14,7 +14,7 @@ app.add_typer(github_app, name="github", rich_help_panel="Code Source")
 @github_app.command()
 async def setup():
     """
-    Initialize a new GitHub integration.
+    Setup Prefect Cloud GitHub integration
     """
     app.console.print("Setting up Prefect Cloud GitHub integration...")
     async with await get_prefect_cloud_client() as client:

--- a/src/prefect_cloud/cli/root.py
+++ b/src/prefect_cloud/cli/root.py
@@ -14,7 +14,11 @@ from prefect_cloud.cli.utilities import (
     process_key_value_pairs,
 )
 from prefect_cloud.dependencies import get_dependencies
-from prefect_cloud.github import FileNotFound, GitHubRepo, infer_repo_url
+from prefect_cloud.github import (
+    FileNotFound,
+    GitHubRepo,
+    infer_repo_url,
+)
 from prefect_cloud.schemas.objects import (
     CronSchedule,
     DeploymentSchedule,

--- a/src/prefect_cloud/cli/utilities.py
+++ b/src/prefect_cloud/cli/utilities.py
@@ -25,6 +25,17 @@ def exit_with_error(
     raise typer.Exit(1)
 
 
+def exit_with_success(
+    message: str | Exception, progress: Progress | None = None
+) -> NoReturn:
+    from prefect_cloud.cli.root import app
+
+    if progress:
+        progress.stop()
+    app.console.print(message, style="green")
+    raise typer.Exit(0)
+
+
 def with_cli_exception_handling(fn: Callable[..., Any]) -> Callable[..., Any]:
     @functools.wraps(fn)
     def wrapper(*args: Any, **kwargs: Any) -> Any:

--- a/tests/test_cli/test_github.py
+++ b/tests/test_cli/test_github.py
@@ -1,0 +1,90 @@
+from unittest.mock import AsyncMock, patch
+
+from tests.test_cli.test_root import invoke_and_assert
+
+
+def test_github_setup():
+    """Test the GitHub setup command."""
+    with patch(
+        "prefect_cloud.cli.github.install_github_app_interactively"
+    ) as mock_install:
+        # Mock the installation function
+        mock_install.return_value = None
+
+        # Run the CLI command
+        invoke_and_assert(
+            command=["github", "setup"],
+            expected_code=0,
+            expected_output_contains=[
+                "Setting up Prefect Cloud GitHub integration...",
+                "Setup complete!",
+            ],
+        )
+
+        # Verify the installation function was called
+        mock_install.assert_called_once()
+
+
+def test_github_ls_with_repositories():
+    """Test the GitHub ls command when repositories are available."""
+    with patch("prefect_cloud.auth.get_prefect_cloud_client") as mock_client:
+        # Setup mock client
+        client = AsyncMock()
+        mock_client.return_value.__aenter__.return_value = client
+
+        # Mock repositories
+        test_repos = ["owner/repo1", "owner/repo2", "owner/repo3"]
+        client.get_github_repositories.return_value = test_repos
+
+        # Run the CLI command
+        invoke_and_assert(
+            command=["github", "ls"],
+            expected_code=0,
+            expected_output_contains=test_repos,
+        )
+
+        # Verify the get_github_repositories function was called
+        client.get_github_repositories.assert_called_once()
+
+
+def test_github_ls_no_repositories():
+    """Test the GitHub ls command when no repositories are available."""
+    with patch("prefect_cloud.auth.get_prefect_cloud_client") as mock_client:
+        # Setup mock client
+        client = AsyncMock()
+        mock_client.return_value.__aenter__.return_value = client
+
+        # Mock empty repositories list
+        client.get_github_repositories.return_value = []
+
+        # Run the CLI command
+        invoke_and_assert(
+            command=["github", "ls"],
+            expected_code=1,  # Should exit with error
+            expected_output_contains=[
+                "No repositories found!",
+                "Configure the Prefect Cloud GitHub integration with `prefect-cloud github setup`.",
+            ],
+        )
+
+        # Verify the get_github_repositories function was called
+        client.get_github_repositories.assert_called_once()
+
+
+def test_github_ls_exception_handling():
+    """Test the GitHub ls command when an exception occurs."""
+    with patch("prefect_cloud.auth.get_prefect_cloud_client") as mock_client:
+        # Setup mock client to raise an exception
+        client = AsyncMock()
+        mock_client.return_value.__aenter__.return_value = client
+        client.get_github_repositories.side_effect = Exception("Connection error")
+
+        # Run the CLI command
+        invoke_and_assert(
+            command=["github", "ls"],
+            expected_code=1,  # Should exit with error
+            expected_output_contains="Connection error",
+        )
+
+        # Verify the get_github_repositories function was called
+        client.get_github_repositories.assert_called_once()


### PR DESCRIPTION
This PR adds a new CLI command group `github` that includes the following two commands:

- `prefect-cloud github setup`: Will pop open a browser window and let you configure the Prefect Cloud Github App for your repositories. While you do this setup, we'll wait for a callback to make sure the loop is completed.

-  `prefect-cloud github ls`:  Will list all the repositories that you currently have access to via the Prefect Cloud Github App