### PR TITLE
Deploy code with Prefect Cloud Github App

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ prefect-cloud deploy ... --env KEY=VALUE --env KEY2=VALUE2
 ```
 
 **From a Private Repository**
+
+*(Recommended!)*
+Install the Prefect Cloud Github App into the repository you want to deploy from. 
+This will allow you to deploy from private repositories without needing to provide a personal access token.
+```bash
+prefect-cloud github setup
+```
+
+Alternatively, you can provide a personal access token on each deploy:
 ```bash
 prefect-cloud deploy ... --from <private source repo URL> --credentials GITHUB_TOKEN
 ```

--- a/src/prefect_cloud/cli/__init__.py
+++ b/src/prefect_cloud/cli/__init__.py
@@ -1,8 +1,6 @@
 # pyright: reportUnusedImport=false
 
-import prefect_cloud.cli.root
-
 # Import CLI submodules to register them to the app
 # isort: split
 
-import prefect_cloud.cli.github  # noqa: F401
+from . import github  # noqa: F401

--- a/src/prefect_cloud/cli/github.py
+++ b/src/prefect_cloud/cli/github.py
@@ -37,7 +37,7 @@ async def ls():
         if not repos:
             exit_with_error(
                 "No repositories found! "
-                "Configure the Prefect Cloud GitHub integration with `prefect-cloud github setup`."
+                "Install the Prefect Cloud GitHub App with `prefect-cloud github setup`."
             )
 
         app.console.print("You can deploy from the following repositories:")

--- a/src/prefect_cloud/cli/root.py
+++ b/src/prefect_cloud/cli/root.py
@@ -119,21 +119,51 @@ async def deploy(
             transient=True,
         ) as progress:
             task = progress.add_task("Inspecting code...", total=None)
-
-            # Pre-process CLI arguments
             env_vars = process_key_value_pairs(env, progress=progress)
-
-            # Get repository info and file contents
+            pull_steps = []
             github_ref = GitHubRepo.from_url(repo)
+
+            # Get file contents
             try:
-                raw_contents = await github_ref.get_file_contents(filepath, credentials)
+                # via `--credentials`
+                if credentials:
+                    raw_contents = await github_ref.get_file_contents(
+                        filepath, credentials
+                    )
+                    block_name = safe_block_name(
+                        f"{github_ref.owner}-{github_ref.repo}-credentials"
+                    )
+                    await client.create_credentials_secret(
+                        name=block_name, credentials=credentials
+                    )
+                    pull_steps.extend(
+                        github_ref.private_repo_via_block_pull_steps(block_name)
+                    )
+                # via GitHub App installation
+                elif credentials_via_app := await client.get_github_token(
+                    github_ref.owner, github_ref.repo
+                ):
+                    raw_contents = await github_ref.get_file_contents(
+                        filepath, credentials_via_app
+                    )
+                    pull_steps.extend(
+                        github_ref.private_repo_via_github_app_pull_steps()
+                    )
+                # Otherwise assume public repo
+                else:
+                    raw_contents = await github_ref.get_file_contents(filepath)
+                    pull_steps.extend(github_ref.public_repo_pull_steps())
             except FileNotFound:
                 exit_with_error(
-                    "Unable to access file in Github. "
-                    "If it's in a private repository retry with `--credentials`.",
+                    f"Unable to access file {filepath} in {github_ref.owner}/{github_ref.repo}. "
+                    f"Make sure the file exists and is accessible.\n"
+                    f"If this is a private repository, you can:\n"
+                    f"1. Install the Prefect Cloud GitHub App with `prefect-cloud github setup` (recommended)\n"
+                    f"2. Pass credentials with `--credentials` flag",
                     progress=progress,
                 )
 
+            # Process function parameters
             try:
                 parameter_schema = get_parameter_schema_from_content(
                     raw_contents, function
@@ -144,20 +174,13 @@ async def deploy(
                     progress=progress,
                 )
 
+            # Provision infrastructure
             progress.update(task, description="Provisioning infrastructure...")
             work_pool = await client.ensure_managed_work_pool()
 
-            credentials_name = None
-            if credentials:
-                progress.update(task, description="Syncing credentials...")
-                credentials_name = safe_block_name(
-                    f"{github_ref.owner}-{github_ref.repo}-credentials"
-                )
-                await client.create_credentials_secret(credentials_name, credentials)
-
             progress.update(task, description="Deploying code...")
 
-            pull_steps = [github_ref.to_pull_step(credentials_name)]
+            # Create Deployment
             if dependencies:
                 quoted_dependencies = [
                     f"'{dependency}'" for dependency in get_dependencies(dependencies)

--- a/src/prefect_cloud/client.py
+++ b/src/prefect_cloud/client.py
@@ -86,24 +86,33 @@ class PrefectCloudClient(httpx.AsyncClient):
         response.raise_for_status()
         return response.json()["state_token"]
 
-    async def get_github_token(self, repository: str, owner: str) -> str | None:
+    async def get_github_token(
+        self,
+        owner: str,
+        repository: str,
+    ) -> str | None:
         """
         Get a GitHub token for a specific repository.
 
         Args:
-            repository: The GitHub repository name
             owner: The GitHub repository owner
+            repository: The GitHub repository name
 
         Returns:
-            The response data
+            The GitHub token or None
         """
-        response = await self.account_request(
-            "POST",
-            "integrations/github/token",
-            json={"repository": repository, "owner": owner},
-        )
-
-        response.raise_for_status()
+        try:
+            response = await self.account_request(
+                "POST",
+                "integrations/github/token",
+                json={
+                    "owner": owner,
+                    "repository": repository,
+                },
+            )
+            response.raise_for_status()
+        except HTTPStatusError:
+            return None
 
         return response.json()["token"]
 

--- a/src/prefect_cloud/github.py
+++ b/src/prefect_cloud/github.py
@@ -108,18 +108,70 @@ class GitHubRepo:
             response.raise_for_status()
             return response.text
 
-    def to_pull_step(self, credentials_block: str | None = None) -> dict[str, Any]:
-        pull_step_kwargs = {
-            "id": "git-clone",
-            "repository": self.clone_url,
-            "branch": self.ref,
-        }
-        if credentials_block:
-            pull_step_kwargs["access_token"] = (
-                "{{ prefect.blocks.secret." + credentials_block + " }}"
-            )
+    def public_repo_pull_steps(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "prefect.deployments.steps.git_clone": {
+                    "id": "git-clone",
+                    "repository": self.clone_url,
+                    "branch": self.ref,
+                }
+            }
+        ]
 
-        return {"prefect.deployments.steps.git_clone": pull_step_kwargs}
+    def private_repo_via_block_pull_steps(
+        self, credentials_block: str
+    ) -> list[dict[str, Any]]:
+        return [
+            {
+                "prefect.deployments.steps.git_clone": {
+                    "id": "git-clone",
+                    "repository": self.clone_url,
+                    "branch": self.ref,
+                    "access_token": "{{ prefect.blocks.secret."
+                    + credentials_block
+                    + " }}",
+                }
+            }
+        ]
+
+    def private_repo_via_github_app_pull_steps(self) -> list[dict[str, Any]]:
+        clone_url = self.clone_url.replace(
+            "https://", "https://x-access-token:{{ get-github-token.stdout }}@"
+        )
+        return [
+            # Get GitHub App installation token
+            {
+                "prefect.deployments.steps.run_shell_script": {
+                    "id": "get-github-token",
+                    "script": self.get_token_command(),
+                }
+            },
+            # Clone Step
+            {
+                "prefect.deployments.steps.git_clone": {
+                    "id": "git-clone",
+                    "repository": clone_url,
+                    "branch": self.ref,
+                }
+            },
+        ]
+
+    def get_token_command(self) -> str:
+        return (
+            r'python -c "import os, urllib.request, urllib.parse, json; '
+            f'owner=\\"{self.owner}\\"; '
+            f'repository=\\"{self.repo}\\"; '
+            r"prefect_api_url=os.environ.get(\"PREFECT_API_URL\", \"\"); "
+            r"base_url=prefect_api_url.split(\"/workspaces/\")[0] if prefect_api_url and \"/workspaces/\" in prefect_api_url else prefect_api_url; "
+            r"prefect_api_key=os.environ.get(\"PREFECT_API_KEY\", \"\"); "
+            r"req=urllib.request.Request("
+            r"f\"{base_url}/integrations/github/token\", "
+            r"data=json.dumps({\"owner\": owner, \"repository\": repository}).encode(), "
+            r"headers={\"Authorization\": f\"Bearer {prefect_api_key}\", \"Content-Type\": \"application/json\"}, "
+            r"method=\"POST\"); "
+            r'print(json.loads(urllib.request.urlopen(req).read())[\"token\"])"'
+        )
 
 
 def translate_to_http(url: str) -> str:

--- a/tests/test_cli/test_github_cli.py
+++ b/tests/test_cli/test_github_cli.py
@@ -18,10 +18,10 @@ def mock_outgoing_calls(monkeypatch):
         return context_manager
 
     monkeypatch.setattr(
-        "prefect_cloud.cli.code_sources.install_github_app_interactively", AsyncMock()
+        "prefect_cloud.cli.github.install_github_app_interactively", AsyncMock()
     )
     monkeypatch.setattr(
-        "prefect_cloud.cli.code_sources.get_prefect_cloud_client", mock_get_client
+        "prefect_cloud.cli.github.get_prefect_cloud_client", mock_get_client
     )
 
     return install_mock, client_mock

--- a/tests/test_cli/test_github_cli.py
+++ b/tests/test_cli/test_github_cli.py
@@ -18,10 +18,10 @@ def mock_outgoing_calls(monkeypatch):
         return context_manager
 
     monkeypatch.setattr(
-        "prefect_cloud.cli.github.install_github_app_interactively", AsyncMock()
+        "prefect_cloud.cli.code_sources.install_github_app_interactively", AsyncMock()
     )
     monkeypatch.setattr(
-        "prefect_cloud.cli.github.get_prefect_cloud_client", mock_get_client
+        "prefect_cloud.cli.code_sources.get_prefect_cloud_client", mock_get_client
     )
 
     return install_mock, client_mock
@@ -93,8 +93,9 @@ def test_github_ls_no_repositories(mock_outgoing_calls):
         command=["github", "ls"],
         expected_code=1,
         expected_output_contains=[
-            "No repositories found! Configure the Prefect Cloud GitHub integration with",
-            "`prefect-cloud github setup`.",
+            "No repositories found!",
+            "Install the Prefect Cloud GitHub App with `prefect-cloud",
+            "github setup`.",
         ],
     )
 


### PR DESCRIPTION
This PR enables `prefect-cloud deploy ...` to automatically check if the user's account has a github app configured that can access the repo they're trying to deploy from.

If so we'll request an installation token to generate the schema for the function directly from github. We'll also add an additional pull step to request an additional token at runtime.

Ultimately I'd like to include this as an interactive step similar to login, however it got way too convoluted so I wanted to make sure this worked first. We can add that as a follow up (all that means right now is you need to run `prefect-cloud github setup` separately)

related to ENG-1309