### PR TITLE
Add default parameter support when creating a deployment

### DIFF
--- a/src/prefect_cloud/cli/root.py
+++ b/src/prefect_cloud/cli/root.py
@@ -92,6 +92,13 @@ async def deploy(
         rich_help_panel="Configuration",
         show_default=False,
     ),
+    parameters: list[str] = typer.Option(
+        ...,
+        "--parameter",
+        "-p",
+        help="Parameter default values in <NAME=VALUE> format (can be used multiple times)",
+        default_factory=list,
+    ),
 ):
     """
     Deploy a Python function to Prefect Cloud
@@ -121,6 +128,9 @@ async def deploy(
         ) as progress:
             task = progress.add_task("Inspecting code...", total=None)
             env_vars = process_key_value_pairs(env, progress=progress)
+            parameter_defaults = process_key_value_pairs(
+                parameters, progress=progress, as_json=True
+            )
             pull_steps: list[dict[str, Any]] = []
             github_ref = GitHubRepo.from_url(repo)
 
@@ -215,6 +225,7 @@ async def deploy(
                 job_variables={
                     "env": {"PREFECT_CLOUD_API_URL": api_url} | env_vars,
                 },
+                parameters=parameter_defaults,
             )
 
             progress.update(task, completed=True, description="Code deployed!")

--- a/src/prefect_cloud/cli/root.py
+++ b/src/prefect_cloud/cli/root.py
@@ -1,4 +1,5 @@
 from uuid import UUID
+from typing import Any
 
 import typer
 import tzlocal
@@ -120,7 +121,7 @@ async def deploy(
         ) as progress:
             task = progress.add_task("Inspecting code...", total=None)
             env_vars = process_key_value_pairs(env, progress=progress)
-            pull_steps = []
+            pull_steps: list[dict[str, Any]] = []
             github_ref = GitHubRepo.from_url(repo)
 
             # Get file contents

--- a/src/prefect_cloud/client.py
+++ b/src/prefect_cloud/client.py
@@ -231,6 +231,7 @@ class PrefectCloudClient(httpx.AsyncClient):
         pull_steps: list[dict[str, Any]] | None = None,
         parameter_openapi_schema: dict[str, Any] | None = None,
         job_variables: dict[str, Any] | None = None,
+        parameters: dict[str, Any] | None = None,
     ) -> "UUID":
         """
         Create a deployment.
@@ -244,7 +245,7 @@ class PrefectCloudClient(httpx.AsyncClient):
             parameter_openapi_schema: OpenAPI schema for flow parameters
             job_variables: A dictionary of dot delimited infrastructure overrides that
                 will be applied at runtime
-
+            parameters: Default parameter values to pass to the flow at runtime
         Returns:
             the ID of the deployment in the backend
         """
@@ -261,6 +262,7 @@ class PrefectCloudClient(httpx.AsyncClient):
             pull_steps=pull_steps,
             parameter_openapi_schema=parameter_openapi_schema,
             job_variables=dict(job_variables or {}),
+            parameters=parameters or {},
         )
 
         json = deployment_create.model_dump(mode="json")
@@ -705,6 +707,7 @@ class PrefectCloudClient(httpx.AsyncClient):
         pull_steps: list[dict[str, Any]],
         parameter_schema: ParameterSchema,
         job_variables: dict[str, Any] | None = None,
+        parameters: dict[str, Any] | None = None,
     ):
         flow_id = await self.create_flow_from_name(function)
 
@@ -716,6 +719,7 @@ class PrefectCloudClient(httpx.AsyncClient):
             pull_steps=pull_steps,
             parameter_openapi_schema=parameter_schema.model_dump_for_openapi(),
             job_variables=job_variables,
+            parameters=parameters,
         )
 
         return deployment_id

--- a/src/prefect_cloud/client.py
+++ b/src/prefect_cloud/client.py
@@ -720,7 +720,7 @@ class PrefectCloudClient(httpx.AsyncClient):
 
         return deployment_id
 
-    async def create_credentials_secret(self, name: str, credentials: str):
+    async def create_credentials_secret(self, name: str, credentials: str) -> None:
         try:
             secret_block_type = await self.read_block_type_by_slug("secret")
             secret_block_schema = (
@@ -739,6 +739,7 @@ class PrefectCloudClient(httpx.AsyncClient):
                     block_schema_id=secret_block_schema.id,
                 )
             )
+            return None
         except HTTPStatusError:
             raise
 

--- a/src/prefect_cloud/schemas/actions.py
+++ b/src/prefect_cloud/schemas/actions.py
@@ -39,6 +39,10 @@ class DeploymentCreate(BaseModel):
         default_factory=dict,
         description="Overrides to apply to flow run infrastructure at runtime.",
     )
+    parameters: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Default parameter values to pass to the flow at runtime.",
+    )
 
 
 class BlockDocumentCreate(BaseModel):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -34,6 +34,7 @@ def mock_deployment() -> DeploymentResponse:
         name="test-deployment",
         work_pool_name="test-pool",
         schedules=[],
+        parameters={},
     )
 
 


### PR DESCRIPTION
This permits `create_deployment()` to create default parameter values by accepting parameters=dict[str, Any]. They are supported on the CLI in the same way as env vars (e.g. `prefect-cloud deploy ... -p x=123 -p y=abc`, except we attempt to parse them as JSON to ensure they are properly forwarded to the API without stringification.