### PR TITLE
CLI QOL updates

### DIFF
--- a/src/prefect_cloud/auth.py
+++ b/src/prefect_cloud/auth.py
@@ -229,10 +229,10 @@ def login_server() -> Generator[Any, None, None]:
         def process_post(
             self, path: str, data: dict[str, Any]
         ) -> str | None | LoginError:
-            if path == "/success":
-                return data.get("api_key") or None
-            elif path == "/failure":
-                return LoginError("Login cancelled by user")
+            if path == "/failure":
+                raise LoginError("Login cancelled by user")
+
+            return data.get("api_key") or None
 
     with callback_server(handler_class=LoginHandler) as callback_ctx:
         yield callback_ctx

--- a/src/prefect_cloud/cli/github.py
+++ b/src/prefect_cloud/cli/github.py
@@ -20,12 +20,18 @@ async def setup():
         async with await get_prefect_cloud_client() as client:
             await install_github_app_interactively(client)
             repos = await client.get_github_repositories()
-            repos_list = "\n".join([f"  - {repo}" for repo in repos])
-            app.exit_with_success(
-                f"[bold]✓[/] Prefect Cloud Github integration complete!\n\n"
-                f"Connected repositories:\n"
-                f"{repos_list}"
-            )
+
+            if repos:
+                repos_list = "\n".join([f"  - {repo}" for repo in repos])
+                app.exit_with_success(
+                    f"[bold]✓[/] Prefect Cloud Github integration complete\n\n"
+                    f"Connected repositories:\n"
+                    f"{repos_list}"
+                )
+            else:
+                app.exit_with_error(
+                    "[bold]✗[/] No repositories found, integration may have unsuccessful"
+                )
 
 
 @github_app.command()
@@ -38,7 +44,7 @@ async def ls():
 
         if not repos:
             app.exit_with_error(
-                "No repositories found!\n\n"
+                "No repositories found.\n\n"
                 "Install the Prefect Cloud GitHub App with:\n"
                 "prefect-cloud github setup"
             )

--- a/src/prefect_cloud/cli/github.py
+++ b/src/prefect_cloud/cli/github.py
@@ -14,14 +14,18 @@ async def setup():
     """
     Setup Prefect Cloud GitHub integration
     """
-    app.print("Setting up Prefect Cloud GitHub integration...")
-    async with await get_prefect_cloud_client() as client:
-        await install_github_app_interactively(client)
-        repos = await client.get_github_repositories()
-        repos_list = "\n".join([f"  - {repo}" for repo in repos])
-        app.exit_with_success(
-            f"[bold]Setup complete! You can now deploy from the following repositories:\n{repos_list}"
-        )
+
+    with app.create_progress() as progress:
+        progress.add_task("Setting up Prefect Cloud GitHub integration...")
+        async with await get_prefect_cloud_client() as client:
+            await install_github_app_interactively(client)
+            repos = await client.get_github_repositories()
+            repos_list = "\n".join([f"  - {repo}" for repo in repos])
+            app.exit_with_success(
+                f"[bold]✓[/] Prefect Cloud Github integration complete!\n\n"
+                f"Connected repositories:\n"
+                f"{repos_list}"
+            )
 
 
 @github_app.command()
@@ -34,10 +38,11 @@ async def ls():
 
         if not repos:
             app.exit_with_error(
-                "No repositories found! "
-                "Install the Prefect Cloud GitHub App with `prefect-cloud github setup`."
+                "No repositories found!\n\n"
+                "Install the Prefect Cloud GitHub App with:\n"
+                "prefect-cloud github setup"
             )
 
-        app.print("You can deploy from the following repositories:")
-        for repo in repos:
-            app.print(f"  - {repo}")
+        repos = await client.get_github_repositories()
+        repos_list = "\n".join([f"- {repo}" for repo in repos])
+        app.exit_with_success(f"Connected repositories:\n{repos_list}")

--- a/src/prefect_cloud/cli/github.py
+++ b/src/prefect_cloud/cli/github.py
@@ -2,8 +2,6 @@ from prefect_cloud.auth import get_prefect_cloud_client
 from prefect_cloud.cli.root import app
 from prefect_cloud.cli.utilities import (
     PrefectCloudTyper,
-    exit_with_error,
-    exit_with_success,
 )
 from prefect_cloud.github import install_github_app_interactively
 
@@ -16,13 +14,13 @@ async def setup():
     """
     Setup Prefect Cloud GitHub integration
     """
-    app.console.print("Setting up Prefect Cloud GitHub integration...")
+    app.print("Setting up Prefect Cloud GitHub integration...")
     async with await get_prefect_cloud_client() as client:
         await install_github_app_interactively(client)
         repos = await client.get_github_repositories()
         repos_list = "\n".join([f"  - {repo}" for repo in repos])
-        exit_with_success(
-            f"Setup complete! You can now deploy from the following repositories:\n{repos_list}"
+        app.exit_with_success(
+            f"[bold]Setup complete! You can now deploy from the following repositories:\n{repos_list}"
         )
 
 
@@ -35,11 +33,11 @@ async def ls():
         repos = await client.get_github_repositories()
 
         if not repos:
-            exit_with_error(
+            app.exit_with_error(
                 "No repositories found! "
                 "Install the Prefect Cloud GitHub App with `prefect-cloud github setup`."
             )
 
-        app.console.print("You can deploy from the following repositories:")
+        app.print("You can deploy from the following repositories:")
         for repo in repos:
-            app.console.print(f"  - {repo}")
+            app.print(f"  - {repo}")

--- a/src/prefect_cloud/cli/root.py
+++ b/src/prefect_cloud/cli/root.py
@@ -5,6 +5,8 @@ import typer
 import tzlocal
 from rich.table import Table
 from rich.text import Text
+from rich.columns import Columns
+from rich.panel import Panel
 
 from prefect_cloud import auth, deployments
 from prefect_cloud.cli import completions
@@ -254,13 +256,11 @@ async def deploy(
             )
 
         deployment_url = f"{ui_url}/deployments/deployment/{deployment_id}"
-        run_cmd = f"$ prefect-cloud run {function}/{deployment_name}"
-        schedule_cmd = (
-            f"$ prefect-cloud schedule {function}/{deployment_name} '<CRON SCHEDULE>'"
-        )
+        run_cmd = f"prefect-cloud run {function}/{deployment_name}"
+        schedule_cmd = f"prefect-cloud schedule {function}/{deployment_name} <SCHEDULE>"
 
         app.print(
-            f"Deployed [cyan]{deployment_name} to Prefect Cloud!\n",
+            f"Deployed [bold cyan]{deployment_name}[/] to Prefect Cloud 🎉\n\n",
             f"Runs of this deployment will "
             f"clone [bold][cyan]{repo}[/cyan][/bold] to "
             f"execute [bold][cyan]{function}[/cyan][/bold] ",
@@ -269,13 +269,29 @@ async def deploy(
         )
 
         app.print(
-            f"[bold]Run[/bold] it with: [bold][cyan]{run_cmd}[/cyan][/bold]\n",
-            f"[bold]Schedule[/bold] it with: [bold][cyan]{schedule_cmd}[/cyan][/bold]\n",
-            "[bold]View[/bold] it at: ",
+            "View it at: ",
             Text(deployment_url, style="link", justify="left"),
             soft_wrap=True,
             sep="",
         )
+
+        run_panel = Panel(
+            Text(run_cmd, style="bold green"),
+            title="Run",
+            border_style="green",
+            padding=(1, 2),
+        )
+
+        schedule_panel = Panel(
+            Text(schedule_cmd, style="bold blue"),
+            title="Schedule",
+            border_style="blue",
+            padding=(1, 2),
+        )
+
+        # Display panels side by side if there's enough space, otherwise stacked
+        app.print("\nCommands:")
+        app.print(Columns([run_panel, schedule_panel], expand=True))
 
         if work_pool.is_paused:
             work_pool_url = f"{ui_url}/work-pools"
@@ -336,7 +352,7 @@ async def run(
     flow_run_url = f"{ui_url}/runs/flow-run/{flow_run.id}"
 
     app.print(
-        f"[bold]Started flow run [cyan]{flow_run.name}[/cyan]! 🚀[/bold]\n└─► View:",
+        f"Started flow run [bold cyan]{flow_run.name}[/] 🚀\nView at: ",
         Text(flow_run_url, style="link", justify="left"),
         soft_wrap=True,
     )

--- a/src/prefect_cloud/cli/root.py
+++ b/src/prefect_cloud/cli/root.py
@@ -3,7 +3,6 @@ from typing import Annotated, Any
 
 import typer
 import tzlocal
-from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 from rich.text import Text
 
@@ -11,7 +10,6 @@ from prefect_cloud import auth, deployments
 from prefect_cloud.cli import completions
 from prefect_cloud.cli.utilities import (
     PrefectCloudTyper,
-    exit_with_error,
     process_key_value_pairs,
 )
 from prefect_cloud.dependencies import get_dependencies
@@ -139,6 +137,8 @@ async def deploy(
     Deploy with a requirements file:
     $ prefect-cloud deploy flows/hello.py:my_function --from github.com/owner/repo --with-requirements requirements.txt
     """
+    app.quiet = quiet
+
     # Initialize default values
     dependencies = dependencies or []
     env = env or []
@@ -151,24 +151,16 @@ async def deploy(
         filepath, function = function.split(":")
         filepath = filepath.lstrip("/")
     except ValueError:
-        exit_with_error("Invalid function. Expected path/to/file.py:function_name")
+        app.exit_with_error("Invalid function. Expected path/to/file.py:function_name")
 
     async with await auth.get_prefect_cloud_client() as client:
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("[cyan]{task.description}"),
-            transient=True,
-            disable=quiet,
-        ) as progress:
-            task = progress.add_task("Inspecting code...", total=None)
-            env_vars = process_key_value_pairs(env, progress=progress)
-            parameter_defaults = process_key_value_pairs(
-                parameters, progress=progress, as_json=True
-            )
+        with app.create_progress() as progress:
+            task = progress.add_task("Inspecting code...")
+            env_vars = process_key_value_pairs(env)
+            parameter_defaults = process_key_value_pairs(parameters, as_json=True)
             pull_steps: list[dict[str, Any]] = []
             github_ref = GitHubRepo.from_url(repo)
 
-            # Get file contents
             try:
                 # via `--credentials`
                 if credentials:
@@ -199,13 +191,12 @@ async def deploy(
                     raw_contents = await github_ref.get_file_contents(filepath)
                     pull_steps.extend(github_ref.public_repo_pull_steps())
             except FileNotFound:
-                exit_with_error(
+                app.exit_with_error(
                     f"Unable to access file {filepath} in {github_ref.owner}/{github_ref.repo}. "
                     f"Make sure the file exists and is accessible.\n"
                     f"If this is a private repository, you can:\n"
                     f"1. Install the Prefect Cloud GitHub App with `prefect-cloud github setup` (recommended)\n"
                     f"2. Pass credentials with `--credentials` flag",
-                    progress=progress,
                 )
 
             # Process function parameters
@@ -214,9 +205,8 @@ async def deploy(
                     raw_contents, function
                 )
             except ValueError:
-                exit_with_error(
+                app.exit_with_error(
                     f"Could not find function '{function}' in {filepath}",
-                    progress=progress,
                 )
 
             # Provision infrastructure
@@ -270,36 +260,35 @@ async def deploy(
             f"prefect-cloud schedule {function}/{deployment_name} '<CRON SCHEDULE>'"
         )
 
-        if not quiet:
-            app.console.print(
-                f"[bold]Deployed [cyan]{deployment_name}[/cyan] to Prefect Cloud! 🎉[/bold]\n",
-                "\n",
-                f"Runs of this deployment will "
-                f"clone [bold][cyan]{repo}[/cyan][/bold] to "
-                f"execute [bold][cyan]{function}[/cyan][/bold] ",
-                f"from [bold][cyan]{filepath}[/cyan][/bold].\n",
-                sep="",
-            )
+        app.print(
+            f"[bold]Deployed [cyan]{deployment_name}[/cyan] to Prefect Cloud! 🎉[/bold]\n",
+            "\n",
+            f"Runs of this deployment will "
+            f"clone [bold][cyan]{repo}[/cyan][/bold] to "
+            f"execute [bold][cyan]{function}[/cyan][/bold] ",
+            f"from [bold][cyan]{filepath}[/cyan][/bold].\n",
+            sep="",
+        )
 
-            app.console.print(
-                f"[bold]Run[/bold] it with: [bold][cyan]{run_cmd}[/cyan][/bold]\n",
-                f"[bold]Schedule[/bold] it with: [bold][cyan]{schedule_cmd}[/cyan][/bold]\n",
-                "[bold]View[/bold] it at: ",
-                Text(deployment_url, style="link", justify="left"),
+        app.print(
+            f"[bold]Run[/bold] it with: [bold][cyan]{run_cmd}[/cyan][/bold]\n",
+            f"[bold]Schedule[/bold] it with: [bold][cyan]{schedule_cmd}[/cyan][/bold]\n",
+            "[bold]View[/bold] it at: ",
+            Text(deployment_url, style="link", justify="left"),
+            soft_wrap=True,
+            sep="",
+        )
+
+        if work_pool.is_paused:
+            work_pool_url = f"{ui_url}/work-pools"
+            print()
+            app.print(
+                "[bold][orange1]Note:[/orange1][/bold] A deployment will not run while "
+                "its work pool is [bold]paused[/bold]. [bold]Resume[/bold] "
+                "the work pool at",
+                Text(work_pool_url, style="link", justify="left"),
                 soft_wrap=True,
-                sep="",
             )
-
-            if work_pool.is_paused:
-                work_pool_url = f"{ui_url}/work-pools"
-                print()
-                app.console.print(
-                    "[bold][orange1]Note:[/orange1][/bold] A deployment will not run while "
-                    "its work pool is [bold]paused[/bold]. [bold]Resume[/bold] "
-                    "the work pool at",
-                    Text(work_pool_url, style="link", justify="left"),
-                    soft_wrap=True,
-                )
 
         return deployment_id
 
@@ -323,6 +312,14 @@ async def run(
             show_default=False,
         ),
     ] = None,
+    quiet: Annotated[
+        bool,
+        typer.Option(
+            "--quiet",
+            "-q",
+            help="Suppress output",
+        ),
+    ] = False,
 ):
     """
     Run a deployment immediately
@@ -330,6 +327,8 @@ async def run(
     Examples:
         $ prefect-cloud run flow_name/deployment_name
     """
+    app.quiet = quiet
+
     parameters = parameters or []
 
     ui_url, _, _ = await auth.get_cloud_urls_or_login()
@@ -338,7 +337,7 @@ async def run(
     flow_run = await deployments.run(deployment, func_kwargs)
     flow_run_url = f"{ui_url}/runs/flow-run/{flow_run.id}"
 
-    app.console.print(
+    app.print(
         f"[bold]Started flow run [cyan]{flow_run.name}[/cyan]! 🚀[/bold]\n└─► View:",
         Text(flow_run_url, style="link", justify="left"),
         soft_wrap=True,
@@ -350,7 +349,7 @@ async def run(
 
     work_pool_url = f"{ui_url}/work-pools"
     if work_pool.is_paused:
-        app.console.print(
+        app.print(
             "\n",
             "[bold][orange1]Note:[/orange1][/bold] Your managed work pool is",
             "currently [bold]paused[/bold]. This will prevent the deployment "
@@ -443,7 +442,7 @@ async def ls():
         elif isinstance(schedule.schedule, RRuleSchedule):  # type: ignore[reportUnnecessaryIsInstance]
             description = f"{schedule.schedule.rrule}"
         else:
-            app.console.print(f"Unknown schedule type: {type(schedule.schedule)}")
+            app.print(f"Unknown schedule type: {type(schedule.schedule)}")
             description = "Unknown"
 
         return Text(f"{prefix} {description}", style=style)
@@ -468,9 +467,9 @@ async def ls():
             str(deployment.id),
         )
 
-    app.console.print(table)
+    app.print(table)
 
-    app.console.print(
+    app.print(
         "* Cron cheatsheet: minute hour day-of-month month day-of-week",
         style="dim",
     )
@@ -510,6 +509,14 @@ async def login(
             help="Workspace ID or slug",
         ),
     ] = None,
+    quiet: Annotated[
+        bool,
+        typer.Option(
+            "--quiet",
+            "-q",
+            help="Suppress output",
+        ),
+    ] = False,
 ):
     """
     Log in to Prefect Cloud
@@ -524,15 +531,36 @@ async def login(
         Login to specific workspace:
         $ prefect-cloud login --workspace your-workspace
     """
-    await auth.login(api_key=key, workspace_id_or_slug=workspace)
+    app.quiet = quiet
+
+    with app.create_progress() as progress:
+        progress.add_task("Logging in to Prefect Cloud...")
+        try:
+            await auth.login(api_key=key, workspace_id_or_slug=workspace)
+        except auth.LoginError:
+            app.exit_with_error("[bold]✗[/] Unable to complete login to Prefect Cloud")
+
+    app.exit_with_success("[bold]✓[/] Logged in to Prefect Cloud")
 
 
 @app.command(rich_help_panel="Auth")
-def logout():
+def logout(
+    quiet: Annotated[
+        bool,
+        typer.Option(
+            "--quiet",
+            "-q",
+            help="Suppress output",
+        ),
+    ] = False,
+):
     """
     Log out of Prefect Cloud
     """
+    app.quiet = quiet
+
     auth.logout()
+    app.exit_with_success("[bold]✓[/] Logged out of Prefect Cloud")
 
 
 @app.command(rich_help_panel="Auth")
@@ -564,9 +592,9 @@ async def whoami() -> None:
     table.add_row("API URL", api_url)
     table.add_row("API Key", redacted(api_key))
 
-    app.console.print(table)
+    app.print(table)
 
-    app.console.print("")
+    app.print("")
 
     table = Table(title="Accounts and Workspaces", show_header=True)
     table.add_column("Account")
@@ -602,4 +630,4 @@ async def whoami() -> None:
                 Text(str(workspace.workspace_id)),
             )
 
-    app.console.print(table)
+    app.print(table)

--- a/src/prefect_cloud/cli/root.py
+++ b/src/prefect_cloud/cli/root.py
@@ -5,8 +5,6 @@ import typer
 import tzlocal
 from rich.table import Table
 from rich.text import Text
-from rich.columns import Columns
-from rich.panel import Panel
 
 from prefect_cloud import auth, deployments
 from prefect_cloud.cli import completions
@@ -269,29 +267,13 @@ async def deploy(
         )
 
         app.print(
-            "View it at: ",
+            "View at: ",
             Text(deployment_url, style="link", justify="left"),
             soft_wrap=True,
             sep="",
         )
-
-        run_panel = Panel(
-            Text(run_cmd, style="bold green"),
-            title="Run",
-            border_style="green",
-            padding=(1, 2),
-        )
-
-        schedule_panel = Panel(
-            Text(schedule_cmd, style="bold blue"),
-            title="Schedule",
-            border_style="blue",
-            padding=(1, 2),
-        )
-
-        # Display panels side by side if there's enough space, otherwise stacked
-        app.print("\nCommands:")
-        app.print(Columns([run_panel, schedule_panel], expand=True))
+        app.print("")
+        app.print(f"Run: [cyan]{run_cmd}[/cyan]\nSchedule: [cyan]{schedule_cmd}[/cyan]")
 
         if work_pool.is_paused:
             work_pool_url = f"{ui_url}/work-pools"
@@ -352,7 +334,7 @@ async def run(
     flow_run_url = f"{ui_url}/runs/flow-run/{flow_run.id}"
 
     app.print(
-        f"Started flow run [bold cyan]{flow_run.name}[/] 🚀\nView at: ",
+        f"Started flow run [bold cyan]{flow_run.name}[/] 🚀\nView at:",
         Text(flow_run_url, style="link", justify="left"),
         soft_wrap=True,
     )

--- a/src/prefect_cloud/cli/utilities.py
+++ b/src/prefect_cloud/cli/utilities.py
@@ -222,6 +222,25 @@ class PrefectCloudTyper(typer.Typer):
         """Get the currently active progress bar if any."""
         return self._current_progress
 
+    @contextmanager
+    def suppress_progress(self) -> Generator[None, None, None]:
+        """
+        Context manager that temporarily suppresses the current progress bar.
+        Restores the original progress bar after exiting the context.
+
+        Example:
+            with app.suppress_progress():
+                # code that shouldn't display progress
+        """
+        if self._current_progress:
+            self._current_progress.stop()
+
+        try:
+            yield
+        finally:
+            if self._current_progress:
+                self._current_progress.start()
+
     def print(self, *args: Any, **kwargs: Any) -> None:
         """Print a message unless quiet mode is enabled."""
         if not self.quiet:

--- a/src/prefect_cloud/cli/utilities.py
+++ b/src/prefect_cloud/cli/utilities.py
@@ -129,7 +129,7 @@ class PrefectCloudTyper(typer.Typer):
                 raise  # Do not capture click or typer exceptions
             except Exception:
                 traceback.print_exc()
-                self.exit_with_error("An exception occurred.")
+                self.exit_with_error("An error occurred.")
 
         return wrapper
 

--- a/src/prefect_cloud/github.py
+++ b/src/prefect_cloud/github.py
@@ -17,7 +17,7 @@ class FileNotFound(Exception):
     pass
 
 
-class InferRepoError(Exception):
+class RepoUnknown(Exception):
     pass
 
 
@@ -213,7 +213,7 @@ def infer_repo_url() -> str:
         return url
 
     except (subprocess.CalledProcessError, ValueError):
-        raise InferRepoError(
+        raise RepoUnknown(
             "No repository specified, and this directory doesn't appear to be a "
             "GitHub repository.  Specify --from to indicate where Prefect Cloud will "
             "download your code from."

--- a/src/prefect_cloud/github.py
+++ b/src/prefect_cloud/github.py
@@ -9,12 +9,15 @@ from urllib.parse import quote, urlparse
 from httpx import AsyncClient
 
 from prefect_cloud.auth import CLOUD_UI_URL, get_account_id
-from prefect_cloud.cli.utilities import exit_with_error
 from prefect_cloud.client import PrefectCloudClient
 from prefect_cloud.utilities.callback import callback_server
 
 
 class FileNotFound(Exception):
+    pass
+
+
+class InferRepoError(Exception):
     pass
 
 
@@ -210,7 +213,7 @@ def infer_repo_url() -> str:
         return url
 
     except (subprocess.CalledProcessError, ValueError):
-        exit_with_error(
+        raise InferRepoError(
             "No repository specified, and this directory doesn't appear to be a "
             "GitHub repository.  Specify --from to indicate where Prefect Cloud will "
             "download your code from."

--- a/src/prefect_cloud/utilities/exception.py
+++ b/src/prefect_cloud/utilities/exception.py
@@ -25,12 +25,6 @@ class ObjectNotFound(Exception):
         return self.help_message or super().__str__()
 
 
-class MissingProfileError(ValueError):
-    """
-    Raised when a profile name does not exist.
-    """
-
-
 class ObjectAlreadyExists(Exception):
     """
     Raised when the client receives a 409 (conflict) from the API.

--- a/src/prefect_cloud/utilities/tui.py
+++ b/src/prefect_cloud/utilities/tui.py
@@ -1,7 +1,6 @@
 import sys
 
 import readchar
-from rich.console import Console
 from rich.live import Live
 from rich.table import Table
 
@@ -15,7 +14,8 @@ def redacted(value: str) -> str:
 def prompt_select_from_list(prompt: str, options: list[str]) -> str:
     """
     Given a list of options, display up to 10 values to user in a table and prompt them
-    to select one, with scrolling support for longer lists.
+    to select one, with scrolling support for longer lists. After selection, collapses
+    to show only the header and selected option.
 
     Args:
         prompt: The prompt text to display to the user
@@ -26,17 +26,22 @@ def prompt_select_from_list(prompt: str, options: list[str]) -> str:
     Returns:
         str: the selected option
     """
-    console = Console()
+    from prefect_cloud.cli.root import app
+
+    console = app.console
 
     current_idx = 0
     selected_option = None
     page_size = 10
     scroll_offset = 0
 
-    def build_table() -> Table:
+    def build_table(collapse: bool = False) -> Table:
         """
         Generate a table of options. The `current_idx` will be highlighted,
         showing only page_size items at a time with scrolling indicators.
+
+        Args:
+            collapse: If True, only show the header and selected option
         """
         nonlocal scroll_offset
 
@@ -50,49 +55,69 @@ def prompt_select_from_list(prompt: str, options: list[str]) -> str:
 
         table = Table(box=None, header_style=None, padding=(0, 0))
 
-        table.add_column(
-            f"? {prompt} [bright_blue][Use arrows to move; enter to select;]",
-            justify="left",
-            no_wrap=True,
-        )
+        # For final display, remove the navigation instructions
+        if collapse:
+            table.add_column(
+                f"? {prompt}",
+                justify="left",
+                no_wrap=True,
+            )
+        else:
+            table.add_column(
+                f"? {prompt} [bright_blue][Use arrows to move; enter to select;]",
+                justify="left",
+                no_wrap=True,
+            )
 
-        for i, option in enumerate(visible_options, start=scroll_offset):
-            if isinstance(option, tuple):
-                display_option = option[1]
-            else:
-                display_option = option
+        if collapse:
+            # Only show the selected option
+            selected_display = options[current_idx]
+            if isinstance(selected_display, tuple):
+                selected_display = selected_display[1]
+            table.add_row("[bold][blue]❯ " + selected_display)
+        else:
+            # Show all visible options
+            for i, option in enumerate(visible_options, start=scroll_offset):
+                if isinstance(option, tuple):
+                    display_option = option[1]
+                else:
+                    display_option = option
 
-            if i == current_idx:
-                table.add_row("[bold][blue]❯ " + display_option)
-            else:
-                table.add_row("  " + display_option)
+                if i == current_idx:
+                    table.add_row("[bold][blue]❯ " + display_option)
+                else:
+                    table.add_row("  " + display_option)
 
         return table
 
-    with Live(build_table(), auto_refresh=False, console=console) as live:
-        while selected_option is None:
-            key = readchar.readkey()
+    with app.suppress_progress():
+        with Live(build_table(), auto_refresh=False, console=console) as live:
+            while selected_option is None:
+                key = readchar.readkey()
 
-            if key == readchar.key.UP:
-                current_idx = (current_idx - 1) % len(options)
-            elif key == readchar.key.DOWN:
-                current_idx = (current_idx + 1) % len(options)
-            elif key == readchar.key.PAGE_UP:
-                current_idx = max(0, current_idx - page_size)
-            elif key == readchar.key.PAGE_DOWN:
-                current_idx = min(len(options) - 1, current_idx + page_size)
-            elif key == readchar.key.HOME:
-                current_idx = 0
-            elif key == readchar.key.END:
-                current_idx = len(options) - 1
-            elif key == readchar.key.CTRL_C:
-                sys.exit(1)
-            elif key == readchar.key.ENTER or key == readchar.key.CR:
-                selected_option = options[current_idx]
-                if isinstance(selected_option, tuple):
-                    selected_option = selected_option[0]
+                if key == readchar.key.UP:
+                    current_idx = (current_idx - 1) % len(options)
+                elif key == readchar.key.DOWN:
+                    current_idx = (current_idx + 1) % len(options)
+                elif key == readchar.key.PAGE_UP:
+                    current_idx = max(0, current_idx - page_size)
+                elif key == readchar.key.PAGE_DOWN:
+                    current_idx = min(len(options) - 1, current_idx + page_size)
+                elif key == readchar.key.HOME:
+                    current_idx = 0
+                elif key == readchar.key.END:
+                    current_idx = len(options) - 1
+                elif key == readchar.key.CTRL_C:
+                    sys.exit(1)
+                elif key == readchar.key.ENTER or key == readchar.key.CR:
+                    selected_option = options[current_idx]
+                    if isinstance(selected_option, tuple):
+                        selected_option = selected_option[0]
+                    # Update the live display with the collapsed view before exiting
+                    live.update(build_table(collapse=True), refresh=True)
+                    break
 
-            if selected_option is None:
-                live.update(build_table(), refresh=True)
+                if selected_option is None:
+                    live.update(build_table(), refresh=True)
 
     return selected_option

--- a/src/prefect_cloud/utilities/tui.py
+++ b/src/prefect_cloud/utilities/tui.py
@@ -56,9 +56,6 @@ def prompt_select_from_list(prompt: str, options: list[str]) -> str:
             no_wrap=True,
         )
 
-        if scroll_offset > 0:
-            table.add_row("[bright_black]  ↑ More options above")
-
         for i, option in enumerate(visible_options, start=scroll_offset):
             if isinstance(option, tuple):
                 display_option = option[1]
@@ -70,9 +67,6 @@ def prompt_select_from_list(prompt: str, options: list[str]) -> str:
             else:
                 table.add_row("  " + display_option)
 
-        if visible_range_end < len(options):
-            table.add_row("[bright_black]  ↓ More options below")
-
         return table
 
     with Live(build_table(), auto_refresh=False, console=console) as live:
@@ -80,9 +74,9 @@ def prompt_select_from_list(prompt: str, options: list[str]) -> str:
             key = readchar.readkey()
 
             if key == readchar.key.UP:
-                current_idx = max(0, current_idx - 1)
+                current_idx = (current_idx - 1) % len(options)
             elif key == readchar.key.DOWN:
-                current_idx = min(len(options) - 1, current_idx + 1)
+                current_idx = (current_idx + 1) % len(options)
             elif key == readchar.key.PAGE_UP:
                 current_idx = max(0, current_idx - page_size)
             elif key == readchar.key.PAGE_DOWN:

--- a/src/prefect_cloud/utilities/tui.py
+++ b/src/prefect_cloud/utilities/tui.py
@@ -1,6 +1,7 @@
 import sys
 
 import readchar
+from rich.console import Console
 from rich.live import Live
 from rich.table import Table
 
@@ -26,9 +27,8 @@ def prompt_select_from_list(prompt: str, options: list[str]) -> str:
     Returns:
         str: the selected option
     """
-    from prefect_cloud.cli.root import app
 
-    console = app.console
+    console = Console()
 
     current_idx = 0
     selected_option = None
@@ -89,6 +89,8 @@ def prompt_select_from_list(prompt: str, options: list[str]) -> str:
                     table.add_row("  " + display_option)
 
         return table
+
+    from prefect_cloud.cli.root import app
 
     with app.suppress_progress():
         with Live(build_table(), auto_refresh=False, console=console) as live:

--- a/src/prefect_cloud/utilities/tui.py
+++ b/src/prefect_cloud/utilities/tui.py
@@ -14,10 +14,11 @@ def redacted(value: str) -> str:
 
 def prompt_select_from_list(prompt: str, options: list[str]) -> str:
     """
-    Given a list of options, display the values to user in a table and prompt them
-    to select one.
+    Given a list of options, display up to 10 values to user in a table and prompt them
+    to select one, with scrolling support for longer lists.
 
     Args:
+        prompt: The prompt text to display to the user
         options: A list of options to present to the user.
             A list of tuples can be passed as key value pairs. If a value is chosen, the
             key will be returned.
@@ -25,33 +26,53 @@ def prompt_select_from_list(prompt: str, options: list[str]) -> str:
     Returns:
         str: the selected option
     """
-
     console = Console()
 
     current_idx = 0
     selected_option = None
+    page_size = 10
+    scroll_offset = 0
 
     def build_table() -> Table:
         """
-        Generate a table of options. The `current_idx` will be highlighted.
+        Generate a table of options. The `current_idx` will be highlighted,
+        showing only page_size items at a time with scrolling indicators.
         """
+        nonlocal scroll_offset
+
+        if current_idx >= scroll_offset + page_size:
+            scroll_offset = current_idx - page_size + 1
+        elif current_idx < scroll_offset:
+            scroll_offset = current_idx
+
+        visible_range_end = min(scroll_offset + page_size, len(options))
+        visible_options = options[scroll_offset:visible_range_end]
 
         table = Table(box=None, header_style=None, padding=(0, 0))
+
         table.add_column(
-            f"? [bold]{prompt}[/] [bright_blue][Use arrows to move; enter to select]",
+            f"? {prompt} [bright_blue][Use arrows to move; enter to select;]",
             justify="left",
             no_wrap=True,
         )
 
-        for i, option in enumerate(options):
+        if scroll_offset > 0:
+            table.add_row("[bright_black]  ↑ More options above")
+
+        for i, option in enumerate(visible_options, start=scroll_offset):
             if isinstance(option, tuple):
-                option = option[1]
+                display_option = option[1]
+            else:
+                display_option = option
 
             if i == current_idx:
-                # Use blue for selected options
-                table.add_row("[bold][blue]> " + option)
+                table.add_row("[bold][blue]❯ " + display_option)
             else:
-                table.add_row("  " + option)
+                table.add_row("  " + display_option)
+
+        if visible_range_end < len(options):
+            table.add_row("[bright_black]  ↓ More options below")
+
         return table
 
     with Live(build_table(), auto_refresh=False, console=console) as live:
@@ -59,15 +80,17 @@ def prompt_select_from_list(prompt: str, options: list[str]) -> str:
             key = readchar.readkey()
 
             if key == readchar.key.UP:
-                current_idx = current_idx - 1
-                # wrap to bottom if at the top
-                if current_idx < 0:
-                    current_idx = len(options) - 1
+                current_idx = max(0, current_idx - 1)
             elif key == readchar.key.DOWN:
-                current_idx = current_idx + 1
-                # wrap to top if at the bottom
-                if current_idx >= len(options):
-                    current_idx = 0
+                current_idx = min(len(options) - 1, current_idx + 1)
+            elif key == readchar.key.PAGE_UP:
+                current_idx = max(0, current_idx - page_size)
+            elif key == readchar.key.PAGE_DOWN:
+                current_idx = min(len(options) - 1, current_idx + page_size)
+            elif key == readchar.key.HOME:
+                current_idx = 0
+            elif key == readchar.key.END:
+                current_idx = len(options) - 1
             elif key == readchar.key.CTRL_C:
                 sys.exit(1)
             elif key == readchar.key.ENTER or key == readchar.key.CR:
@@ -75,6 +98,7 @@ def prompt_select_from_list(prompt: str, options: list[str]) -> str:
                 if isinstance(selected_option, tuple):
                     selected_option = selected_option[0]
 
-            live.update(build_table(), refresh=True)
+            if selected_option is None:
+                live.update(build_table(), refresh=True)
 
-        return selected_option
+    return selected_option

--- a/tests/test_cli/test_github_cli.py
+++ b/tests/test_cli/test_github_cli.py
@@ -38,9 +38,8 @@ def test_github_setup(mock_outgoing_calls):
         command=["github", "setup"],
         expected_code=0,
         expected_output_contains=[
-            "Setting up Prefect Cloud GitHub integration...",
-            "Setup complete!",
-            "You can now deploy from the following repositories:",
+            "✓ Prefect Cloud Github integration complete",
+            "Connected repositories:",
             "- owner/repo1",
             "- owner/repo2",
         ],
@@ -55,11 +54,9 @@ def test_github_setup_no_repositories(mock_outgoing_calls):
 
     invoke_and_assert(
         command=["github", "setup"],
-        expected_code=0,
+        expected_code=1,
         expected_output_contains=[
-            "Setting up Prefect Cloud GitHub integration...",
-            "Setup complete!",
-            "You can now deploy from the following repositories:",
+            "✗ No repositories found, integration may have unsuccessful"
         ],
     )
 
@@ -75,7 +72,7 @@ def test_github_ls_with_repositories(mock_outgoing_calls):
         command=["github", "ls"],
         expected_code=0,
         expected_output_contains=[
-            "You can deploy from the following repositories:",
+            "Connected repositories:",
             "- owner/repo1",
             "- owner/repo2",
             "- owner/repo3",
@@ -93,9 +90,9 @@ def test_github_ls_no_repositories(mock_outgoing_calls):
         command=["github", "ls"],
         expected_code=1,
         expected_output_contains=[
-            "No repositories found!",
-            "Install the Prefect Cloud GitHub App with `prefect-cloud",
-            "github setup`.",
+            "No repositories found.",
+            "Install the Prefect Cloud GitHub App with:",
+            "prefect-cloud github setup",
         ],
     )
 

--- a/tests/test_cli/test_root.py
+++ b/tests/test_cli/test_root.py
@@ -235,7 +235,7 @@ def test_deploy_command_basic():
                     expected_output_contains=[
                         "Deployed test_function",
                         "prefect-cloud run test_function/test_function",
-                        "prefect-cloud schedule test_function/test_function '<CRON SCHEDULE>'",
+                        "prefect-cloud schedule test_function/test_function <SCHEDULE>",
                         "https://ui.url/deployments/deployment/test-deployment-id",
                     ],
                 )
@@ -348,7 +348,7 @@ def test_deploy_with_env_vars():
                         expected_output_contains=[
                             "Deployed test_function",
                             "prefect-cloud run test_function/test_function",
-                            "prefect-cloud schedule test_function/test_function '<CRON SCHEDULE>'",
+                            "prefect-cloud schedule test_function/test_function <SCHEDULE>",
                             "https://ui.url/deployments/deployment/test-deployment-id",
                             "github.com/owner/repo",
                         ],
@@ -423,7 +423,7 @@ def test_deploy_with_parameters():
                         expected_output_contains=[
                             "Deployed test_function",
                             "prefect-cloud run test_function/test_function",
-                            "prefect-cloud schedule test_function/test_function '<CRON SCHEDULE>'",
+                            "prefect-cloud schedule test_function/test_function <SCHEDULE>",
                             "https://ui.url/deployments/deployment/test-deployment-id",
                             "github.com/owner/repo",
                         ],
@@ -508,7 +508,7 @@ def test_deploy_with_private_repo_credentials():
                     expected_output_contains=[
                         "Deployed test_function",
                         "prefect-cloud run test_function/test_function",
-                        "prefect-cloud schedule test_function/test_function '<CRON SCHEDULE>'",
+                        "prefect-cloud schedule test_function/test_function <SCHEDULE>",
                         "https://ui.url/deployments/deployment/test-deployment-id",
                         "github.com/owner/repo",
                     ],
@@ -617,8 +617,8 @@ def test_run():
                     ],
                     expected_code=0,
                     expected_output_contains=[
-                        "Started flow run test-run! 🚀",
-                        "View: https://ui.url/runs/flow-run/test-run-id",
+                        "Started flow run test-run",
+                        "View at: https://ui.url/runs/flow-run/test-run-id",
                     ],
                 )
 
@@ -684,7 +684,7 @@ def test_deploy_with_dependencies():
                         expected_output_contains=[
                             "Deployed test_function",
                             "prefect-cloud run test_function/test_function",
-                            "prefect-cloud schedule test_function/test_function '<CRON SCHEDULE>'",
+                            "prefect-cloud schedule test_function/test_function <SCHEDULE>",
                             "https://ui.url/deployments/deployment/test-deployment-id",
                             "github.com/owner/repo",
                         ],
@@ -763,7 +763,7 @@ def test_deploy_with_requirements_file():
                         expected_output_contains=[
                             "Deployed test_function",
                             "prefect-cloud run test_function/test_function",
-                            "prefect-cloud schedule test_function/test_function '<CRON SCHEDULE>'",
+                            "prefect-cloud schedule test_function/test_function <SCHEDULE>",
                             "https://ui.url/deployments/deployment/test-deployment-id",
                             "github.com/owner/repo",
                         ],
@@ -843,7 +843,7 @@ def test_deploy_with_github_app():
                         expected_output_contains=[
                             "Deployed test_function",
                             "prefect-cloud run test_function/test_function",
-                            "prefect-cloud schedule test_function/test_function '<CRON SCHEDULE>'",
+                            "prefect-cloud schedule test_function/test_function <SCHEDULE>",
                             "https://ui.url/deployments/deployment/test-deployment-id",
                             "github.com/owner/repo",
                         ],
@@ -911,7 +911,7 @@ def test_deploy_with_quiet_flag():
                     expected_output_does_not_contain=[
                         "Deployed test_function",
                         "prefect-cloud run test_function/test_function",
-                        "prefect-cloud schedule test_function/test_function '<CRON SCHEDULE>'",
+                        "prefect-cloud schedule test_function/test_function <SCHEDULE>",
                         "https://ui.url/deployments/deployment/test-deployment-id",
                     ],
                 )
@@ -1017,7 +1017,7 @@ def test_deploy_with_custom_deployment_name():
                     expected_output_contains=[
                         "Deployed custom-deployment-name",
                         "prefect-cloud run test_function/custom-deployment-name",
-                        "prefect-cloud schedule test_function/custom-deployment-name '<CRON SCHEDULE>'",
+                        "prefect-cloud schedule test_function/custom-deployment-name <SCHEDULE>",
                         "https://ui.url/deployments/deployment/test-deployment-id",
                     ],
                 )

--- a/tests/test_cli/test_utilities.py
+++ b/tests/test_cli/test_utilities.py
@@ -1,6 +1,5 @@
 import pytest
 from prefect_cloud.cli.utilities import process_key_value_pairs
-import typer
 
 
 def test_process_key_value_pairs():
@@ -22,15 +21,15 @@ def test_process_key_value_pairs():
     assert process_key_value_pairs(input_list) == expected
 
     # Test with invalid format
-    with pytest.raises(typer.Exit):
+    with pytest.raises(ValueError):
         process_key_value_pairs(["invalid_format"])
 
     # Test with missing value
-    with pytest.raises(typer.Exit):
+    with pytest.raises(ValueError):
         process_key_value_pairs(["key1=value1", "key2="])
 
     # Test with missing key
-    with pytest.raises(typer.Exit):
+    with pytest.raises(ValueError):
         process_key_value_pairs(["=value"])
 
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -3,12 +3,12 @@ import subprocess
 import tempfile
 from pathlib import Path
 
-import click.exceptions
 import pytest
 from httpx import Response
 
 from prefect_cloud.github import (
     FileNotFound,
+    RepoUnknown,
     GitHubRepo,
     get_local_repo_urls,
     infer_repo_url,
@@ -305,7 +305,7 @@ class TestInferRepoUrl:
         with tempfile.TemporaryDirectory() as temp_dir:
             os.chdir(temp_dir)
 
-            with pytest.raises(click.exceptions.Exit):
+            with pytest.raises(RepoUnknown):
                 infer_repo_url()
 
     def test_exits_when_not_github_url(self, git_repo: Path):
@@ -321,7 +321,7 @@ class TestInferRepoUrl:
             capture_output=True,
         )
 
-        with pytest.raises(click.exceptions.Exit):
+        with pytest.raises(RepoUnknown):
             infer_repo_url()
 
 


### PR DESCRIPTION
This PR fixes a couple of QOL issues and attempts to apply some standards around our CLI output. It has the following changes:
- The callback server now supports raising errors, which will be re-raised in the main thread
- This lets us correct handle the post to `/failure` from the UI, if the user hits the "cancel" button on authorization
- Refactors a lot the output mechanisms to be attached to `PrefectCloudTyper`. This lets keep things centralized, and do things like exit the current `Progress()` if we're exiting the app, or clear it temporarily if we're doing some other prompting.
- Tries to align copy and formatting across the board (getting rid of the weird arrow notation in outputs, making sure actions have a clear success message, etc.)
- if we're _doing_ something, support a `--quiet` command to suppress output.

I'm not sure I was able to completely achieve what I was hoping for yet in terms of UX. But I think this is a step in the right direction.

CLOSES ENG-1570
CLOSES ENG-1628
CLOSES ENG-1704

