### PR TITLE
Small GitHub related updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ prefect-cloud deploy <path/to/file.py:function_name> --from <source repo URL>
 ```
 e.g.
 ```bash
-prefect-cloud deploy examples/hello.py:hello_world --from https://github.com/PrefectHQ/prefect-cloud/
+prefect-cloud deploy examples/hello.py:hello_world --from PrefectHQ/prefect-cloud
 ```
 
 ### Run it with
@@ -86,7 +86,7 @@ prefect-cloud deploy ... --env KEY=VALUE --env KEY2=VALUE2
 **From a Private Repository**
 
 *(Recommended!)*
-Install the Prefect Cloud Github App into the repository you want to deploy from. 
+Install the Prefect Cloud GitHub App into the repository you want to deploy from. 
 This will allow you to deploy from private repositories without needing to provide a personal access token.
 ```bash
 prefect-cloud github setup

--- a/src/prefect_cloud/cli/github.py
+++ b/src/prefect_cloud/cli/github.py
@@ -24,13 +24,19 @@ async def setup():
             if repos:
                 repos_list = "\n".join([f"  - {repo}" for repo in repos])
                 app.exit_with_success(
-                    f"[bold]✓[/] Prefect Cloud Github integration complete\n\n"
-                    f"Connected repositories:\n"
-                    f"{repos_list}"
+                    f"[bold]✓[/] Prefect Cloud GitHub integration complete\n\n"
+                    f"Connected repositories:\n{repos_list}\n\n"
+                    f"Deploy a function from your repo with:\n"
+                    f"prefect-cloud deploy <file.py:function> --from <github repo>"
                 )
             else:
                 app.exit_with_error(
-                    "[bold]✗[/] No repositories found, integration may have unsuccessful"
+                    "[bold]✗[/] No repositories found\n\n"
+                    "This may mean:\n"
+                    "• The integration was not successful, or\n"
+                    "• The integration is still pending GitHub admin approval\n\n"
+                    "Once approved, you’ll be able to deploy from your GitHub repos using:\n"
+                    "prefect-cloud deploy <file.py:function> --from <github repo>"
                 )
 
 
@@ -44,11 +50,20 @@ async def ls():
 
         if not repos:
             app.exit_with_error(
-                "No repositories found.\n\n"
-                "Install the Prefect Cloud GitHub App with:\n"
-                "prefect-cloud github setup"
+                "[bold]✗[/] No repositories found\n\n"
+                "This likely means:\n"
+                "• The GitHub integration has not been set up, or\n"
+                "• The integration is pending GitHub admin approval\n\n"
+                "To get started:\n"
+                "  Run: prefect-cloud github setup\n\n"
+                "If you've already installed the GitHub App:\n"
+                "  Once a GitHub admin approves the installation, you can deploy from your repos using:\n"
+                "  prefect-cloud deploy <file.py:function> --from <github repo>"
             )
 
-        repos = await client.get_github_repositories()
         repos_list = "\n".join([f"- {repo}" for repo in repos])
-        app.exit_with_success(f"Connected repositories:\n{repos_list}")
+        app.exit_with_success(
+            f"Connected repositories:\n{repos_list}\n\n"
+            f"Deploy a function from your repo with:\n"
+            f"prefect-cloud deploy <file.py:function> --from <github repo>"
+        )

--- a/src/prefect_cloud/cli/github.py
+++ b/src/prefect_cloud/cli/github.py
@@ -24,10 +24,10 @@ async def setup():
             if repos:
                 repos_list = "\n".join([f"  - {repo}" for repo in repos])
                 app.exit_with_success(
-                    f"[bold]✓[/] Prefect Cloud GitHub integration complete\n\n"
+                    "[bold]✓[/] Prefect Cloud GitHub integration complete\n\n"
                     f"Connected repositories:\n{repos_list}\n\n"
-                    f"Deploy a function from your repo with:\n"
-                    f"prefect-cloud deploy <file.py:function> --from <github repo>"
+                    "Deploy a function from your repo with:\n"
+                    "prefect-cloud deploy <file.py:function> --from <github repo>"
                 )
             else:
                 app.exit_with_error(
@@ -56,7 +56,7 @@ async def ls():
                 "• The integration is pending GitHub admin approval\n\n"
                 "To get started:\n"
                 "  Run: prefect-cloud github setup\n\n"
-                "If you've already installed the GitHub App:\n"
+                "If the integration is pending:\n"
                 "  Once a GitHub admin approves the installation, you can deploy from your repos using:\n"
                 "  prefect-cloud deploy <file.py:function> --from <github repo>"
             )

--- a/src/prefect_cloud/cli/root.py
+++ b/src/prefect_cloud/cli/root.py
@@ -53,10 +53,10 @@ async def deploy(
             default_factory=infer_repo_url,
             autocompletion=completions.complete_repo,
             help=(
-                "GitHub repository URL. e.g.\n\n"
-                "• Repo: github.com/owner/repo\n\n"
-                "• Specific branch: github.com/owner/repo/tree/<branch>\n\n"
-                "• Specific commit: github.com/owner/repo/tree/<commit-sha>\n\n"
+                "GitHub repository reference in any of these formats:\n\n"
+                "• owner/repo\n\n"
+                "• owner/repo/tree/branch\n\n"
+                "• owner/repo/tree/commit-sha\n\n"
                 "If not provided, the repository of the current directory will be used."
             ),
             rich_help_panel="Source",

--- a/src/prefect_cloud/github.py
+++ b/src/prefect_cloud/github.py
@@ -268,7 +268,7 @@ def get_local_repo_urls() -> list[str]:
 
 
 def _get_prefect_cloud_github_app() -> str:
-    """Get the Github app name based on environment"""
+    """Get the GitHub app name based on environment"""
 
     env = os.environ.get("CLOUD_ENV")
 

--- a/src/prefect_cloud/github.py
+++ b/src/prefect_cloud/github.py
@@ -39,15 +39,17 @@ class GitHubRepo:
 
     @classmethod
     def from_url(cls, url: str) -> "GitHubRepo":
-        """Parse a GitHub repo URL into its components.
+        """Parse a GitHub repo URL or owner/repo string into its components.
 
         Handles various URL formats:
         - https://github.com/owner/repo
         - github.com/owner/repo/tree/branch
         - github.com/owner/repo/tree/a1b2c3d
+        - owner/repo
+        - owner/repo/tree/branch
 
         Args:
-            url: GitHub URL to parse
+            url: GitHub URL or owner/repo string to parse
 
         Returns:
             GitHubRepo
@@ -55,7 +57,26 @@ class GitHubRepo:
         Raises:
             ValueError: If URL format is invalid
         """
-        normalized_url = url if "://" in url else f"https://{url}"
+        # Special case for simple owner/repo format
+        if "/" in url and not any(
+            x in url for x in ["://", "github.com", "tree", "blob", "raw"]
+        ):
+            parts = url.split("/")
+            if len(parts) == 2:
+                owner, repo = parts
+                return cls(owner=owner, repo=repo.removesuffix(".git"), ref="main")
+            elif len(parts) >= 4 and parts[2] == "tree":
+                owner, repo = parts[0:2]
+                ref = parts[3]
+                return cls(owner=owner, repo=repo.removesuffix(".git"), ref=ref)
+
+        # Handle URL formats as before
+        normalized_url = url
+        if "://" not in url:
+            if not url.startswith("github.com"):
+                normalized_url = f"https://github.com/{url}"
+            else:
+                normalized_url = f"https://{url}"
 
         # Check for GitHub file URLs (blob/raw paths)
         if "/blob/" in normalized_url or "/raw/" in normalized_url:

--- a/tests/test_cli/test_github_cli.py
+++ b/tests/test_cli/test_github_cli.py
@@ -38,7 +38,7 @@ def test_github_setup(mock_outgoing_calls):
         command=["github", "setup"],
         expected_code=0,
         expected_output_contains=[
-            "✓ Prefect Cloud Github integration complete",
+            "✓ Prefect Cloud GitHub integration complete",
             "Connected repositories:",
             "- owner/repo1",
             "- owner/repo2",
@@ -56,7 +56,12 @@ def test_github_setup_no_repositories(mock_outgoing_calls):
         command=["github", "setup"],
         expected_code=1,
         expected_output_contains=[
-            "✗ No repositories found, integration may have unsuccessful"
+            "✗ No repositories found",
+            "This may mean:",
+            "• The integration was not successful, or",
+            "• The integration is still pending GitHub admin approval",
+            "Once approved, you’ll be able to deploy from your GitHub repos using:",
+            "prefect-cloud deploy <file.py:function> --from <github repo>",
         ],
     )
 
@@ -90,9 +95,15 @@ def test_github_ls_no_repositories(mock_outgoing_calls):
         command=["github", "ls"],
         expected_code=1,
         expected_output_contains=[
-            "No repositories found.",
-            "Install the Prefect Cloud GitHub App with:",
-            "prefect-cloud github setup",
+            "✗ No repositories found",
+            "This likely means:",
+            "• The GitHub integration has not been set up, or",
+            "• The integration is pending GitHub admin approval",
+            "To get started:",
+            "  Run: prefect-cloud github setup",
+            "If the integration is pending:",
+            "  Once a GitHub admin approves the installation, you can deploy from your repos",
+            "  prefect-cloud deploy <file.py:function> --from <github repo>",
         ],
     )
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -70,6 +70,33 @@ class TestGitHubRepo:
         assert ref.repo == "example-repo"
         assert ref.ref == "main"
 
+    def test_from_url_simple_owner_repo(self):
+        """Test simple owner/repo format without github.com."""
+        url = "ExampleOwner/example-repo"
+        ref = GitHubRepo.from_url(url)
+
+        assert ref.owner == "ExampleOwner"
+        assert ref.repo == "example-repo"
+        assert ref.ref == "main"
+
+    def test_from_url_owner_repo_with_ref(self):
+        """Test owner/repo/tree/ref format without github.com."""
+        url = "ExampleOwner/example-repo/tree/feature-branch"
+        ref = GitHubRepo.from_url(url)
+
+        assert ref.owner == "ExampleOwner"
+        assert ref.repo == "example-repo"
+        assert ref.ref == "feature-branch"
+
+    def test_from_url_owner_repo_with_git_extension(self):
+        """Test owner/repo.git format."""
+        url = "ExampleOwner/example-repo.git"
+        ref = GitHubRepo.from_url(url)
+
+        assert ref.owner == "ExampleOwner"
+        assert ref.repo == "example-repo"
+        assert ref.ref == "main"
+
     def test_from_url_invalid_github(self):
         """Test that non-GitHub URLs are rejected."""
         with pytest.raises(ValueError, match="Not a GitHub URL"):


### PR DESCRIPTION
CLOSES ENG-1738

This PR makes a couple updates related specifically to the GitHub app and how to deploy from GitHub repos. 
- It adds a call to action after you configure the GitHub app to show what's next
- It updates how we handle `--from` to support the simplified format of `<repo owner>/<repo>` instead of requiring a github.com/ prefix (may need to re-consider this if we support other storage later)
- Fixes a few typos where we have `Github` -> `GitHub`
