### PR TITLE
Use `prefect-client*` images instead

### DIFF
--- a/src/prefect_cloud/py_versions.py
+++ b/src/prefect_cloud/py_versions.py
@@ -8,4 +8,4 @@ class PythonVersion(str, Enum):
     PY_39 = "3.9"
 
     def to_prefect_image(self) -> str:
-        return f"prefecthq/prefect:3-python{self.value}"
+        return f"prefecthq/prefect-client:3-python{self.value}"

--- a/tests/test_cli/test_root.py
+++ b/tests/test_cli/test_root.py
@@ -1130,7 +1130,7 @@ def test_deploy_with_python_version():
                 job_variables = client.create_managed_deployment.call_args[1][
                     "job_variables"
                 ]
-                assert job_variables["image"] == "prefecthq/prefect:3-python3.10"
+                assert job_variables["image"] == "prefecthq/prefect-client:3-python3.10"
 
                 # Reset the mock for the next test
                 client.create_managed_deployment.reset_mock()
@@ -1156,4 +1156,4 @@ def test_deploy_with_python_version():
                 job_variables = client.create_managed_deployment.call_args[1][
                     "job_variables"
                 ]
-                assert job_variables["image"] == "prefecthq/prefect:3-python3.12"
+                assert job_variables["image"] == "prefecthq/prefect-client:3-python3.12"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -195,7 +195,7 @@ async def test_get_default_base_job_template_for_managed_work_pool(
     mock_template = {
         "job_configuration": {
             "command": "python {{ entrypoint }}",
-            "image": "prefecthq/prefect:latest",
+            "image": "prefecthq/prefect-client:3-latest",
         }
     }
 

--- a/tests/test_py_versions.py
+++ b/tests/test_py_versions.py
@@ -9,7 +9,18 @@ def test_python_version_values():
 
 
 def test_to_prefect_image():
-    assert PythonVersion.PY_312.to_prefect_image() == "prefecthq/prefect:3-python3.12"
-    assert PythonVersion.PY_311.to_prefect_image() == "prefecthq/prefect:3-python3.11"
-    assert PythonVersion.PY_310.to_prefect_image() == "prefecthq/prefect:3-python3.10"
-    assert PythonVersion.PY_39.to_prefect_image() == "prefecthq/prefect:3-python3.9"
+    assert (
+        PythonVersion.PY_312.to_prefect_image()
+        == "prefecthq/prefect-client:3-python3.12"
+    )
+    assert (
+        PythonVersion.PY_311.to_prefect_image()
+        == "prefecthq/prefect-client:3-python3.11"
+    )
+    assert (
+        PythonVersion.PY_310.to_prefect_image()
+        == "prefecthq/prefect-client:3-python3.10"
+    )
+    assert (
+        PythonVersion.PY_39.to_prefect_image() == "prefecthq/prefect-client:3-python3.9"
+    )


### PR DESCRIPTION
When we specify the python version, we want to use the best image possible, which is now the client version.