### PR TITLE
Use `prefect-cloud` cli in pull step for GitHub app

### DIFF
--- a/src/prefect_cloud/github.py
+++ b/src/prefect_cloud/github.py
@@ -168,7 +168,7 @@ class GitHubRepo:
             {
                 "prefect.deployments.steps.run_shell_script": {
                     "id": "get-github-token",
-                    "script": self.get_token_command(),
+                    "script": f"uv tool run prefect-cloud github token {self.owner}/{self.repo}",
                 }
             },
             # Clone Step
@@ -180,22 +180,6 @@ class GitHubRepo:
                 }
             },
         ]
-
-    def get_token_command(self) -> str:
-        return (
-            r'python -c "import os, urllib.request, urllib.parse, json; '
-            f'owner=\\"{self.owner}\\"; '
-            f'repository=\\"{self.repo}\\"; '
-            r"prefect_api_url=os.environ.get(\"PREFECT_API_URL\", \"\"); "
-            r"base_url=prefect_api_url.split(\"/workspaces/\")[0] if prefect_api_url and \"/workspaces/\" in prefect_api_url else prefect_api_url; "
-            r"prefect_api_key=os.environ.get(\"PREFECT_API_KEY\", \"\"); "
-            r"req=urllib.request.Request("
-            r"f\"{base_url}/integrations/github/token\", "
-            r"data=json.dumps({\"owner\": owner, \"repository\": repository}).encode(), "
-            r"headers={\"Authorization\": f\"Bearer {prefect_api_key}\", \"Content-Type\": \"application/json\"}, "
-            r"method=\"POST\"); "
-            r'print(json.loads(urllib.request.urlopen(req).read())[\"token\"])"'
-        )
 
 
 def translate_to_http(url: str) -> str:

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -270,24 +270,6 @@ class TestGitHubContent:
             == clone_step["repository"]
         )
 
-    def test_get_token_command(self):
-        """Test generation of the shell command to retrieve GitHub token."""
-        github_ref = GitHubRepo(
-            owner="ExampleOwner",
-            repo="example-repo",
-            ref="main",
-        )
-
-        command = github_ref.get_token_command()
-
-        # Check that it contains necessary components
-        assert 'owner=\\"ExampleOwner\\"' in command
-        assert 'repository=\\"example-repo\\"' in command
-        assert "prefect_api_url" in command
-        assert "prefect_api_key" in command
-        assert "urllib.request.Request" in command
-        assert "/integrations/github/token" in command
-
 
 @pytest.fixture
 def git_repo(tmp_path: Path) -> Path:


### PR DESCRIPTION
Instead of a messy standalone token command we can use `uv tool run prefect-cloud github token {self.owner}/{self.repo}` to use the actual `prefect-cloud` CLI in a place where `prefect-cloud` may or may not be installing