### PR TITLE
Let secrets be passed by reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,14 @@ prefect-cloud deploy ... --env KEY=VALUE --env KEY2=VALUE2
 ```
 
 **Include Secrets as Environment Variables**
+
 ```bash
-prefect-cloud deploy ... --secret KEY=VALUE --secret KEY2=VALUE2
-````
+# Create or replace secrets with actual values
+prefect-cloud deploy ... --secret API_KEY=actual-secret-value --secret DB_PASSWORD=another-secret-value
+
+# Reference existing secret blocks
+prefect-cloud deploy ... --secret API_KEY="{existing-api-key-block}" --secret DB_PASSWORD="{my-database-password}"
+```
 
 **From a Private Repository**
 

--- a/src/prefect_cloud/cli/utilities.py
+++ b/src/prefect_cloud/cli/utilities.py
@@ -53,7 +53,7 @@ def process_key_value_pairs(
             continue
 
         key = key.strip()
-        value = value.strip()
+        value = value.strip().strip("\"'")
 
         if as_json:
             try:

--- a/tests/test_cli/test_utilities.py
+++ b/tests/test_cli/test_utilities.py
@@ -72,3 +72,41 @@ def test_process_key_value_pairs_json():
     # Test empty values with as_json
     assert process_key_value_pairs([], as_json=True) == {}
     assert process_key_value_pairs(None, as_json=True) == {}
+
+
+def test_process_key_value_pairs_strips_whitespace_and_quotes():
+    """Test that surrounding whitespace and quotes are stripped from values."""
+    input_pairs = [
+        "key1=  value1  ",  # Whitespace only
+        'key2="value2"',  # Double quotes
+        "key3='value3'",  # Single quotes
+        'key4=  "value4"  ',  # Whitespace and double quotes
+        "key5=  'value5'  ",  # Whitespace and single quotes
+        "key6={block-slug}",  # Braces (should not be stripped)
+        'key7="{quoted-block}"',  # Braces within quotes
+        'key8=  "  value8  "  ',  # Internal whitespace should remain
+    ]
+    expected = {
+        "key1": "value1",
+        "key2": "value2",
+        "key3": "value3",
+        "key4": "value4",
+        "key5": "value5",
+        "key6": "{block-slug}",
+        "key7": "{quoted-block}",
+        "key8": "  value8  ",  # Internal whitespace remains
+    }
+    assert process_key_value_pairs(input_pairs) == expected
+
+    # Test with as_json=True as well, ensuring stripping happens before JSON parsing attempt
+    input_pairs_json = [
+        'num= "42" ',  # Quoted number
+        'bool=  "true" ',  # Quoted boolean
+        'str="string"',  # Single-quoted string containing double quotes (value becomes "string")
+    ]
+    expected_json = {
+        "num": 42,
+        "bool": True,
+        "str": "string",  # JSON parser handles internal quotes
+    }
+    assert process_key_value_pairs(input_pairs_json, as_json=True) == expected_json


### PR DESCRIPTION
This lets users pass existing secrets by reference so that if you have an existing `Secret` block you can just pass `MY_SECRET_ENV_VAR={existing-secret-block}` instead of passing the actual secret value.