### PR TITLE
Revert uvx to uv tool run in GitHub token script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+CLAUDE.md
+This file provides guidance to Claude Code when working with this repository.
+
+Project Overview
+Prefect Cloud is a package to enable onboarding to Prefect Cloud and works alongside the prefect PyPI package. 
+
+Services:
+
+
+
+Essential Commands
+
+Development Guidelines
+Code Conventions
+Python 3.12 with modern typing syntax
+Avoid # type: ignore, think harder about types
+Follow surrounding code style
+Minimal approaches before complex solutions
+Don't use inline Python imports, except to resolve circular dependencies
+
+Testing
+Test directory structure mirrors src/ structure (e.g., tests/cli/, tests/utilities/)
+
+
+Project Practices
+Use Linear for issue tracking (ENG-/PLA- prefixes), not GitHub issues
+NEVER commit with --no-verify - pre-commit hooks are required
+Run pre-commit run --all-files to validate changes
+Dependency updates: modify requirements.in or requirements-dev.in, then make
+PR closing Linear issues: mention "Closes ENG-1234" in PR body
+CLAUDE.md is always symlinked to AGENTS.md
+PR description should be brief and focused on the problem being solved
+PR descriptions should not include "Test Plan" checklists

--- a/README.md
+++ b/README.md
@@ -22,6 +22,27 @@ uv pip install prefect-cloud
 
 Alternatively, you can run `prefect-cloud` as a tool without installing it using `uvx`. See [uv tools guide](https://docs.astral.sh/uv/guides/tools/) for more details.
 
+## Quick Start with uvx (no installation required)
+
+If you prefer to run without installing, you can use `uvx` to run `prefect-cloud` commands directly:
+
+```bash
+# Login to Prefect Cloud
+uvx prefect-cloud login
+
+# Connect to GitHub (for private repos)
+uvx prefect-cloud github setup
+
+# Deploy your workflow
+uvx prefect-cloud deploy examples/hello.py:hello_world --from PrefectHQ/prefect-cloud
+
+# Run it
+uvx prefect-cloud run hello_world/hello_world
+
+# Schedule it
+uvx prefect-cloud schedule hello_world/hello_world "0 * * * *"
+```
+
 ## Login to Prefect Cloud
 
 ```bash

--- a/src/prefect_cloud/github.py
+++ b/src/prefect_cloud/github.py
@@ -168,7 +168,7 @@ class GitHubRepo:
             {
                 "prefect.deployments.steps.run_shell_script": {
                     "id": "get-github-token",
-                    "script": f"uv tool run prefect-cloud github token {self.owner}/{self.repo}",
+                    "script": f"uvx prefect-cloud github token {self.owner}/{self.repo}",
                 }
             },
             # Clone Step

--- a/src/prefect_cloud/github.py
+++ b/src/prefect_cloud/github.py
@@ -168,7 +168,7 @@ class GitHubRepo:
             {
                 "prefect.deployments.steps.run_shell_script": {
                     "id": "get-github-token",
-                    "script": f"uvx prefect-cloud github token {self.owner}/{self.repo}",
+                    "script": f"uv tool run prefect-cloud github token {self.owner}/{self.repo}",
                 }
             },
             # Clone Step


### PR DESCRIPTION
## Summary
- Reverts the change from `uvx` back to `uv tool run` in the GitHub token script
- This change was causing issues locally and breaks functionality

🤖 Generated with [Claude Code](https://claude.ai/code)