### PR TITLE
Don't use uvx for for getting git token

### DIFF
--- a/src/prefect_cloud/github.py
+++ b/src/prefect_cloud/github.py
@@ -168,6 +168,8 @@ class GitHubRepo:
             {
                 "prefect.deployments.steps.run_shell_script": {
                     "id": "get-github-token",
+                    # The prefect image currently doesn't get built with uvx
+                    # installed. So we use the long name instead of the alias.
                     "script": f"uv tool run prefect-cloud github token {self.owner}/{self.repo}",
                 }
             },

--- a/src/prefect_cloud/github.py
+++ b/src/prefect_cloud/github.py
@@ -168,7 +168,7 @@ class GitHubRepo:
             {
                 "prefect.deployments.steps.run_shell_script": {
                     "id": "get-github-token",
-                    "script": f"uvx prefect-cloud github token {self.owner}/{self.repo}",
+                    "script": f"uv tool run prefect-cloud github token {self.owner}/{self.repo}",
                 }
             },
             # Clone Step


### PR DESCRIPTION
An earlier [PR](https://github.com/PrefectHQ/prefect-cloud/pull/91) swapped `uv tool run` to `uvx` but the prefect image doesn't get built with `uvx` installed by default (possibly an older version of uv or different binary).

This change was thought to be reverted in https://github.com/PrefectHQ/prefect-cloud/pull/92 but it doesn't seem that it was committed.

This PR reverts that change.