### PR TITLE
Fix confusing error message when hitting deployment limits

### DIFF
--- a/src/prefect_cloud/utilities/exception.py
+++ b/src/prefect_cloud/utilities/exception.py
@@ -4,6 +4,8 @@ Prefect-specific exceptions.
 
 from typing import Any, Optional
 
+from httpx import HTTPStatusError
+
 
 class ObjectNotFound(Exception):
     """
@@ -33,3 +35,25 @@ class ObjectAlreadyExists(Exception):
     def __init__(self, http_exc: Exception, *args: Any, **kwargs: Any) -> None:
         self.http_exc = http_exc
         super().__init__(*args, **kwargs)
+
+
+class ForbiddenError(Exception):
+    """
+    Raised when a request returns a 403 Forbidden status.
+
+    This exception automatically extracts and includes the detail message
+    from the API response to provide context about why the request was forbidden.
+    """
+
+    def __init__(self, http_exc: HTTPStatusError, *args: Any, **kwargs: Any) -> None:
+        self.http_exc = http_exc
+
+        message = "Access forbidden"
+        try:
+            detail = http_exc.response.json().get("detail")
+            if detail:
+                message = detail
+        except (ValueError, KeyError):
+            message = f"Access forbidden: {http_exc.response.text or http_exc.response.reason_phrase}"
+
+        super().__init__(message, *args, **kwargs)


### PR DESCRIPTION
## Summary

Fixes CLOUD-2634 where users hitting deployment limits received a confusing error message.

**Before:**
```
httpx.RequestError: Malformed response: <Response [403 Forbidden]>
```

**After:**
```
ForbiddenError: You have reached the maximum number of deployments for your workspace. 
To upgrade please reach out to us by visiting https://cloud.prefect.io/settings/account/.../tier-limits/upgrade 
or contacting your account administrator. Current limit: 2 deployments.
```

## Changes

- Added `ForbiddenError` exception in `utilities/exception.py` that automatically extracts the `detail` field from 403 responses
- Updated `create_deployment()` to call `raise_for_status()` after requests and catch 403 errors specifically
- Raises `ForbiddenError` for 403 responses, providing the clear deployment limit message from the server
- Added comprehensive test coverage for all 403 response scenarios

## Testing

- Added 3 new tests covering 403 responses with detail, without detail, and non-JSON responses
- All existing tests pass (26 total)
- Manually tested with local nebula instance to verify error message is clear

Closes CLOUD-2634