### PR TITLE
Pin tzlocal below 5.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "typer>=0.16.0,<0.22.0",
     "typing-extensions>=4.12.2,<5.0.0",
     "uv>=0.5.26",
-    "tzlocal>=5.2,!=5.4.1,!=5.4.2",
+    "tzlocal>=5.2,<5.4",
     "httpx>=0.28.1,!=0.23.2",
     "pydantic-extra-types>=2.10.2,<3.0.0",
     "toml>=0.10.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "typer>=0.16.0,<0.22.0",
     "typing-extensions>=4.12.2,<5.0.0",
     "uv>=0.5.26",
-    "tzlocal>=5.2",
+    "tzlocal>=5.2,!=5.4.1,!=5.4.2",
     "httpx>=0.28.1,!=0.23.2",
     "pydantic-extra-types>=2.10.2,<3.0.0",
     "toml>=0.10.2",

--- a/src/prefect_cloud/following.py
+++ b/src/prefect_cloud/following.py
@@ -62,7 +62,7 @@ class LogsSubscriber:
         self._api_url = api_url
         self._api_key = api_key
         self._filter = filter or {}
-        self._seen_logs = TTLCache(
+        self._seen_logs = TTLCache[UUID, bool](
             maxsize=10000, ttl=300
         )  # 5 minute TTL, 10k max items
 
@@ -275,7 +275,7 @@ class EventsSubscriber:
         self._api_url = api_url
         self._api_key = api_key
         self._filter = filter or {}
-        self._seen_events = TTLCache(
+        self._seen_events = TTLCache[UUID, bool](
             maxsize=10000, ttl=300
         )  # 5 minute TTL, 10k max items
 

--- a/uv.lock
+++ b/uv.lock
@@ -438,7 +438,7 @@ requires-dist = [
     { name = "toml", specifier = ">=0.10.2" },
     { name = "typer", specifier = ">=0.16.0,<0.22.0" },
     { name = "typing-extensions", specifier = ">=4.12.2,<5.0.0" },
-    { name = "tzlocal", specifier = ">=5.2,!=5.4.1,!=5.4.2" },
+    { name = "tzlocal", specifier = ">=5.2,<5.4" },
     { name = "uv", specifier = ">=0.5.26" },
     { name = "websockets", specifier = ">=15.0.1,<17.0" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -438,7 +438,7 @@ requires-dist = [
     { name = "toml", specifier = ">=0.10.2" },
     { name = "typer", specifier = ">=0.16.0,<0.22.0" },
     { name = "typing-extensions", specifier = ">=4.12.2,<5.0.0" },
-    { name = "tzlocal", specifier = ">=5.2" },
+    { name = "tzlocal", specifier = ">=5.2,!=5.4.1,!=5.4.2" },
     { name = "uv", specifier = ">=0.5.26" },
     { name = "websockets", specifier = ">=15.0.1,<17.0" },
 ]


### PR DESCRIPTION
Pins `tzlocal` below 5.4 for now. The 5.4.x releases include packaging churn: 5.4.1 was yanked, and 5.4.2 currently ships a wheel without the actual `tzlocal` package, causing `uv tool run prefect-cloud ...` to fail at import time during deployment pull steps.

This keeps installs on the known-good 5.3.x line until upstream publishes a stable 5.4.x release.