### PR TITLE
chore(codeowners): migrate to cloud-* engineering teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @PrefectHQ/backend
+* @PrefectHQ/cloud-backend


### PR DESCRIPTION
Replace the broad `@PrefectHQ/backend` CODEOWNERS reference with the product-scoped `@PrefectHQ/cloud-backend` team.

The old `platform`/`backend`/`frontend` teams are being retired; this repo was missed in the first migration pass. 1:1 mapping, no other ownership routing changed.

> [!NOTE]
> Confirm the `cloud-backend` team has access to this repo before merging. GitHub silently ignores CODEOWNERS entries for teams without repo access.

Related to https://linear.app/prefect/issue/ENGPAR-72/revisit-github-engineering-teams