### PR TITLE
Emit GitHub installation tokens without wrapping

### DIFF
--- a/src/prefect_cloud/cli/github.py
+++ b/src/prefect_cloud/cli/github.py
@@ -94,7 +94,7 @@ async def token(
     async with await get_prefect_cloud_client() as client:
         github_token = await client.get_github_token(owner=owner, repository=repo_name)
         if github_token:
-            app.console.print(github_token)
+            typer.echo(github_token)
         else:
             app.exit_with_error(
                 f"Could not retrieve token for repository {repository}.\n"

--- a/tests/test_cli/test_github_cli.py
+++ b/tests/test_cli/test_github_cli.py
@@ -124,13 +124,14 @@ def test_github_ls_exception_handling(mock_outgoing_calls):
 def test_github_token_success(mock_outgoing_calls):
     """Test the GitHub token command successfully retrieves a token."""
     _, client_mock = mock_outgoing_calls
-    expected_token = "ghp_test_token"
+    expected_token = "ghs_" + "x" * 516
     client_mock.get_github_token.return_value = expected_token
 
     invoke_and_assert(
         command=["github", "token", "test-owner/test-repo"],
         expected_code=0,
-        expected_output_contains=expected_token,
+        expected_output=expected_token,
+        expected_line_count=1,
     )
 
     client_mock.get_github_token.assert_called_once_with(


### PR DESCRIPTION
GitHub's new stateless installation tokens can be around 520 characters. `prefect-cloud github token` currently prints through Rich, which hard-wraps at 80 columns when a deployment pull step captures its output. Those newlines become part of the authenticated clone URL and Git aborts before flow code loads.

Emit the token through Typer's raw output and assert that a representative 520-character token remains exactly one line.

Related to https://linear.app/prefect/issue/CLOUD-4318/prefect-cloud-github-token-word-wraps-the-token-corrupting-downstream

## Rollout caveats

- watch: GitHub App-backed deployment pull steps after the next PyPI release — `remote helper 'https' aborted session` clone failures should stop

<details><summary>Session context</summary>

Horizon integration runs began failing after GitHub's staged migration from 40-character installation tokens to variable-length JWT-backed tokens. Reproducing with `COLUMNS=80` showed a 390-character token split into five physical lines. `typer.echo` was chosen over Rich soft wrapping because the token is machine-readable data.

</details>
